### PR TITLE
Add github action for zipping and uploading to IPFS

### DIFF
--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -1,0 +1,61 @@
+name: Prod Release
+
+on:
+  release:
+    types: created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build Extension
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: npm install -g yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+
+      - name: Update manifest.json with release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: node ./manifest-util.js ./public/manifest.json
+
+      - name: Create Extension Zip file
+        run: yarn zip
+
+      - name: Pin to IPFS
+        id: upload
+        uses: anantaramdas/ipfs-pinata-deploy-action@39bbda1ce1fe24c69c6f57861b8038278d53688d
+        with:
+          pin-name: Zodiac Pilot Chrome Extension ${{ github.event.release.tag_name }}
+          path: './zodiac-pilot.zip'
+          pinata-api-key: ${{ secrets.PINATA_API_KEY }}
+          pinata-secret-api-key: ${{ secrets.PINATA_API_SECRET_KEY }}
+
+      - name: Convert CIDv0 to CIDv1
+        id: convert_cidv0
+        uses: uniswap/convert-cidv0-cidv1@v1.0.0
+        with:
+          cidv0: ${{ steps.upload.outputs.hash }}
+
+      - name: update release
+        id: update_release
+        uses: tubone24/update_release@v1.3.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          is_append_body: true
+          body: |
+            <br />
+            This extension will be available in the Chrome Extension store, or you can download it from IPFS, extract it and run it as an unpacked extension.
+
+            IPFS hash of the extension zip file:
+            - CIDv0: `${{ steps.upload.outputs.hash }}`
+            - CIDv1: `${{ steps.convert_cidv0.outputs.cidv1 }}`
+
+            IPFS gateways:
+              - https://gnosis.mypinata.cloud/ipfs/${{ steps.upload.outputs.hash }}
+              - https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.dweb.link/
+              - https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.cf-ipfs.com/

--- a/manifest-util.js
+++ b/manifest-util.js
@@ -1,0 +1,34 @@
+const fs = require('fs')
+
+// this script is used to update the release value
+// in the manifest.json when released through github
+// actions. Meant to be used as a cli script:
+//
+// node manifest-util.js ./public/manifest.json
+
+const main = () => {
+  const manifestPath = process.argv[2];
+  const releaseTag = process.env.RELEASE_TAG;
+  if (!manifestPath) {
+    return console.log('Please provide a path to the Manifest file.')
+  }
+  if (!releaseTag) {
+    return console.log('Please provide a RELEASE_TAG env variable.')
+  }
+
+  updateManifest(manifestPath, releaseTag);
+}
+
+const updateManifest = (manifestFilename, releaseTag) => {
+  try {
+    const data = fs.readFileSync(manifestFilename);
+    const manifest = JSON.parse(data);
+    manifest["version"] = releaseTag;
+    fs.writeFileSync(manifestFilename, JSON.stringify(manifest))
+
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+main();

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Zodiac Pilot",
   "description": "Simulate dApp interactions and record transactions",
-  "version": "1.0.1",
+  "version": "",
   "manifest_version": 3,
   "icons": {
     "16": "zodiac16.png",


### PR DESCRIPTION
This creates a github action that will do the following on every release:

1. Build the extension
2. Modify the `version` field in the `manifest.json` file with the release's tag
3. Create the zip file
4. Upload to IPFS
5. Modify the release notes to include the IPFS hashes and links to the hash on a few different gateways.

@jfschwarz let me know if there's a way of including the functionality of `manifest-util.json` that seems better. A separate script file felt like the lightest touch to me.