### PR TITLE
Update manifest version and add webstore link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/gnosis/zodiac-pilot/actions/workflows/ci.yml/badge.svg)](https://github.com/gnosis/zodiac-pilot/actions/workflows/ci.yml)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/gnosis/CODE_OF_CONDUCT)
 
-Chrome extension to simulate Dapp interactions and record transactions.
+Chrome extension to simulate Dapp interactions and record transactions. [Available on the Chrome Webstore](https://chrome.google.com/webstore/detail/zodiac-pilot/jklckajipokenkbbodifahogmidkekcb?hl=en&authuser=0)
 
 ## Contribute
 
@@ -28,8 +28,6 @@ To enable the extension in Chrome, follow these steps:
 ```
 yarn build
 ```
-
-TODO: figure out how to package for the Chrome extension store
 
 ## How it works
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Zodiac Pilot",
   "description": "Simulate dApp interactions and record transactions",
-  "version": "0.0.0",
+  "version": "1.1.5",
   "manifest_version": 3,
   "icons": {
     "16": "zodiac16.png",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Zodiac Pilot",
   "description": "Simulate dApp interactions and record transactions",
-  "version": "1.1.5",
+  "version": "0.0.0",
   "manifest_version": 3,
   "icons": {
     "16": "zodiac16.png",


### PR DESCRIPTION
The Zodiac Pilot extension is now available in the webstore, this adds the link to the readme. This also adds the latest release version to the `public/manifest.json` file so the published version matches the repo.