### PR TITLE
fix: encoding error on batch submit

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -24,9 +24,9 @@
     "fix:lint": "eslint src --ext .ts --fix"
   },
   "devDependencies": {
-    "@gnosis.pm/safe-core-sdk": "^1.1.1",
-    "@gnosis.pm/safe-ethers-lib": "^1.1.0",
-    "@gnosis.pm/safe-service-client": "^1.0.1",
+    "@gnosis.pm/safe-core-sdk": "^3.1.0",
+    "@gnosis.pm/safe-ethers-lib": "^1.6.0",
+    "@gnosis.pm/safe-service-client": "^1.3.0",
     "@testing-library/jest-dom": "^5.16.1",
     "@typechain/ethers-v5": "^10.0.0",
     "@types/chrome": "^0.0.193",
@@ -37,7 +37,7 @@
     "@types/react-modal": "^3.13.1",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
-    "@walletconnect/ethereum-provider": "^1.6.6",
+    "@walletconnect/ethereum-provider": "^1.8.0",
     "classnames": "^2.3.1",
     "copy-to-clipboard": "^3.3.1",
     "cspell": "^5.13.0",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -12,7 +12,7 @@
   "action": {
     "default_title": "Zodiac Pilot"
   },
-  "permissions": ["tabs", "scripting", "declarativeNetRequest"],
+  "permissions": ["tabs", "declarativeNetRequest"],
   "background": {
     "service_worker": "build/background.js"
   },

--- a/extension/src/app.tsx
+++ b/extension/src/app.tsx
@@ -2,13 +2,13 @@
 // This means it does not have access to chrome.* APIs, but it can interact with other extensions such as MetaMask.
 import React, { useEffect } from 'react'
 import { createRoot } from 'react-dom/client'
-import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 
 import './global.css'
 
 import Browser from './browser'
 import { prependHttp } from './browser/UrlInput'
+import ZodiacToastContainer from './components/Toast'
 import { pushLocation } from './location'
 import { ProvideMetaMask } from './providers'
 import { useMatchSettingsRoute, usePushSettingsRoute } from './routing'
@@ -60,7 +60,7 @@ root.render(
     <ProvideMetaMask>
       <ProvideConnections>
         <Routes />
-        <ToastContainer />
+        <ZodiacToastContainer />
       </ProvideConnections>
     </ProvideMetaMask>
   </React.StrictMode>

--- a/extension/src/browser/Drawer/ContractAddress/index.tsx
+++ b/extension/src/browser/Drawer/ContractAddress/index.tsx
@@ -86,7 +86,7 @@ const ContractAddress: React.FC<Props> = ({
 
   return (
     <Flex
-      gap={3}
+      gap={2}
       alignItems="center"
       justifyContent="space-between"
       className={cn(className, classes.container)}

--- a/extension/src/browser/Drawer/ContractAddress/style.module.css
+++ b/extension/src/browser/Drawer/ContractAddress/style.module.css
@@ -2,6 +2,7 @@
   overflow: hidden;
   width: 25px;
   aspect-ratio: 1;
+  flex-shrink: 0;
 }
 .blockies img {
   border-radius: 50%;
@@ -14,8 +15,14 @@
 
 .addressContainer {
   padding: 10px;
+  flex-shrink: 0;
 }
 
 .link {
   text-decoration: none;
+}
+
+.contractName {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/extension/src/browser/Drawer/RolePermissionCheck.tsx
+++ b/extension/src/browser/Drawer/RolePermissionCheck.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useEffect, useState } from 'react'
 import { RiFileCopy2Line, RiGroupLine } from 'react-icons/ri'
 import { encodeSingle, TransactionInput } from 'react-multisend'
+import { toast } from 'react-toastify'
 
 import { Flex, Tag } from '../../components'
 import { JsonRpcError } from '../../types'
@@ -46,6 +47,7 @@ const RolePermissionCheck: React.FC<{
     navigator.clipboard.writeText(
       JSON.stringify(transactionEncoded, undefined, 2)
     )
+    toast(<>Transaction data has been copied to clipboard.</>)
   }
 
   if (error === undefined) return null

--- a/extension/src/browser/Drawer/RolePermissionCheck.tsx
+++ b/extension/src/browser/Drawer/RolePermissionCheck.tsx
@@ -4,6 +4,7 @@ import { RiFileCopy2Line, RiGroupLine } from 'react-icons/ri'
 import { encodeSingle, TransactionInput } from 'react-multisend'
 
 import { Flex, Tag } from '../../components'
+import { JsonRpcError } from '../../types'
 import { decodeRolesError } from '../../utils'
 import { isPermissionsError } from '../../utils/decodeRolesError'
 import { useWrappingProvider } from '../ProvideProvider'
@@ -29,8 +30,8 @@ const RolePermissionCheck: React.FC<{
       .then(() => {
         if (!canceled) setError(false)
       })
-      .catch((e: string) => {
-        const decodedError = decodeRolesError(e)
+      .catch((e: JsonRpcError) => {
+        const decodedError = decodeRolesError(e.data.message || e.message)
         if (!canceled) {
           setError(isPermissionsError(decodedError) ? decodedError : false)
         }

--- a/extension/src/browser/Drawer/Submit.tsx
+++ b/extension/src/browser/Drawer/Submit.tsx
@@ -37,7 +37,7 @@ const Submit: React.FC = () => {
       const err = e as JsonRpcError
       toast.error(
         <>
-          <p>Transaction batch is failing with the following error:</p>
+          <p>Submitting the transaction batch failed:</p>
           <br />
           <code>{decodeRolesError(err.data.message || err.message)}</code>
         </>

--- a/extension/src/browser/Drawer/Submit.tsx
+++ b/extension/src/browser/Drawer/Submit.tsx
@@ -5,6 +5,7 @@ import Modal, { Styles } from 'react-modal'
 import { toast } from 'react-toastify'
 
 import { Button, IconButton } from '../../components'
+import toastClasses from '../../components/Toast/Toast.module.css'
 import { EXPLORER_URL, NETWORK_PREFIX } from '../../networks'
 import { waitForMultisigExecution } from '../../providers'
 import { useConnection } from '../../settings'
@@ -40,7 +41,8 @@ const Submit: React.FC = () => {
           <p>Submitting the transaction batch failed:</p>
           <br />
           <code>{decodeRolesError(err.data.message || err.message)}</code>
-        </>
+        </>,
+        { className: toastClasses.toastError }
       )
       return
     }
@@ -71,7 +73,6 @@ const Submit: React.FC = () => {
     toast(
       <>
         Transaction batch has been executed
-        <br />
         <a
           href={`${EXPLORER_URL[chainId]}/tx/${realBatchTransactionHash}`}
           target="_blank"

--- a/extension/src/browser/Drawer/Transaction.tsx
+++ b/extension/src/browser/Drawer/Transaction.tsx
@@ -10,7 +10,7 @@ import {
 
 import { Box, Flex, IconButton } from '../../components'
 import ToggleButton from '../../components/Drawer/ToggleButton'
-import { ChainId, NETWORK_CURRENCY } from '../../networks'
+import { NETWORK_CURRENCY } from '../../networks'
 import { ForkProvider } from '../../providers'
 import { useConnection } from '../../settings'
 import { useProvider } from '../ProvideProvider'
@@ -169,7 +169,7 @@ export const Transaction: React.FC<Props> = ({
         <>
           <Box bg p={2} className={classes.subtitleContainer}>
             <Flex
-              gap={2}
+              gap={3}
               alignItems="center"
               justifyContent="space-between"
               className={classes.transactionSubtitle}
@@ -254,10 +254,10 @@ const EtherValue: React.FC<{ input: TransactionInput }> = ({ input }) => {
     <Box p={2} className={classes.value}>
       <Flex gap={1} alignItems="center" justifyContent="space-between">
         <div>Value:</div>
-        <Box p={1} bg>
+        <Box p={1} className={classes.valueValue} bg>
           {valueBN.isZero()
             ? 'n/a'
-            : `${formatEther(valueBN)} ${NETWORK_CURRENCY[chainId as ChainId]}`}
+            : `${formatEther(valueBN)} ${NETWORK_CURRENCY[chainId]}`}
         </Box>
       </Flex>
     </Box>

--- a/extension/src/browser/Drawer/index.tsx
+++ b/extension/src/browser/Drawer/index.tsx
@@ -22,7 +22,7 @@ const TransactionsDrawer: React.FC = () => {
   const dispatch = useDispatch()
   const provider = useProvider()
   const {
-    connection: { avatarAddress, moduleAddress, pilotAddress, roleId, chainId },
+    connection: { avatarAddress, moduleAddress, pilotAddress, roleId },
   } = useConnection()
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)

--- a/extension/src/browser/Drawer/index.tsx
+++ b/extension/src/browser/Drawer/index.tsx
@@ -1,10 +1,12 @@
 import { BigNumber } from 'ethers'
 import React, { useEffect, useRef, useState } from 'react'
-import { RiRefreshLine } from 'react-icons/ri'
-import { encodeSingle } from 'react-multisend'
+import { RiFileCopy2Line, RiRefreshLine } from 'react-icons/ri'
+import { encodeMulti, encodeSingle } from 'react-multisend'
+import { toast } from 'react-toastify'
 
 import { BlockButton, Box, Drawer, Flex, IconButton } from '../../components'
 import { ForkProvider } from '../../providers'
+import { wrapRequest } from '../../providers/WrappingProvider'
 import { useConnection } from '../../settings'
 import { useProvider } from '../ProvideProvider'
 import { useAllTransactions, useDispatch, useNewTransactions } from '../state'
@@ -20,7 +22,7 @@ const TransactionsDrawer: React.FC = () => {
   const dispatch = useDispatch()
   const provider = useProvider()
   const {
-    connection: { avatarAddress },
+    connection: { avatarAddress, moduleAddress, pilotAddress, roleId, chainId },
   } = useConnection()
 
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
@@ -51,9 +53,9 @@ const TransactionsDrawer: React.FC = () => {
 
     await provider.refork()
 
-    // re-simulate all transactions
-    for (let i = 0; i < allTransactions.length; i++) {
-      const transaction = allTransactions[i]
+    // re-simulate all new transactions (assuming the already submitted ones have already been mined on the fresh fork)
+    for (let i = 0; i < newTransactions.length; i++) {
+      const transaction = newTransactions[i]
       const encoded = encodeSingle(transaction.input)
       await provider.request({
         method: 'eth_sendTransaction',
@@ -67,6 +69,25 @@ const TransactionsDrawer: React.FC = () => {
         ],
       })
     }
+  }
+
+  const copyTransactionData = () => {
+    const metaTransactions = newTransactions.map((tx) => encodeSingle(tx.input))
+    const batchTransaction =
+      metaTransactions.length === 1
+        ? metaTransactions[0]
+        : encodeMulti(
+            metaTransactions,
+            '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761'
+          )
+    const wrappedReq = wrapRequest(
+      batchTransaction,
+      pilotAddress,
+      moduleAddress,
+      roleId
+    )
+    navigator.clipboard.writeText(JSON.stringify(wrappedReq, undefined, 2))
+    toast(<>Transaction data has been copied to clipboard.</>)
   }
 
   return (
@@ -116,6 +137,14 @@ const TransactionsDrawer: React.FC = () => {
       <Flex gap={2} alignItems="center">
         <h4 className={classes.header}>Recording Transactions</h4>
         <Flex gap={1} className={classes.headerButtons}>
+          <IconButton
+            title="Copy batch transaction data to clipboard"
+            disabled={newTransactions.length === 0}
+            onClick={copyTransactionData}
+          >
+            <RiFileCopy2Line />
+          </IconButton>
+
           <IconButton
             title="Re-simulate on current blockchain head"
             disabled={newTransactions.length === 0}

--- a/extension/src/browser/Drawer/style.module.css
+++ b/extension/src/browser/Drawer/style.module.css
@@ -103,13 +103,7 @@
 }
 
 .removeTransaction {
-  width: 30px;
-  height: auto;
-  padding: 3px;
-  cursor: pointer;
-  color: #d9d4ad;
-  background-color: rgb(35 35 23);
-  border: 1px solid rgba(217, 212, 173, 0.3);
+  margin: 0 calc(var(--spacing-2) * -1);
 }
 
 .transactionHeader .start {
@@ -142,10 +136,16 @@
 }
 .transactionSubtitle {
   font-size: 0.75em;
+  flex-grow: 1;
 }
 
 .value {
+  max-width: 150px;
+}
+.valueValue {
   font-family: 'Roboto Mono', monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .transactionStatus {

--- a/extension/src/browser/ProvideProvider.tsx
+++ b/extension/src/browser/ProvideProvider.tsx
@@ -138,7 +138,10 @@ const ProvideProvider: React.FC<Props> = ({ simulate, children }) => {
       params: [
         metaTransactions.length === 1
           ? metaTransactions[0]
-          : encodeMulti(metaTransactions),
+          : encodeMulti(
+              metaTransactions,
+              '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761'
+            ),
       ],
     })
     dispatch({

--- a/extension/src/components/Box/style.module.css
+++ b/extension/src/components/Box/style.module.css
@@ -3,6 +3,7 @@
   position: relative;
   transition: all 0.2s ease;
   box-sizing: border-box;
+  min-width: 0; /* prevent content from overflowing container (see: https://stackoverflow.com/questions/36230944/prevent-flex-items-from-overflowing-a-container) */
 }
 .bg {
   background-color: rgba(217, 212, 173, 0.1);

--- a/extension/src/components/Flex/style.module.css
+++ b/extension/src/components/Flex/style.module.css
@@ -1,5 +1,6 @@
 .flex {
   display: flex;
+  min-width: 0;
 }
 .row {
   flex-direction: row;

--- a/extension/src/components/Toast/Toast.module.css
+++ b/extension/src/components/Toast/Toast.module.css
@@ -1,0 +1,34 @@
+.toast,
+.toastError {
+  border-radius: 0;
+  border: 1px solid var(--border-color);
+  background-color: rgb(35 35 23);
+}
+
+.toastError {
+  background: rgb(49 6 6);
+}
+
+.toastBody {
+  font-family: 'Spectral', serif;
+  color: white;
+}
+
+.toastBody code {
+  font-size: 12px;
+  background: #0000005e;
+  display: block;
+  padding: 6px;
+  margin-top: 4px;
+}
+
+.toastBody a {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.toastProgress {
+  background: var(--border-color);
+}

--- a/extension/src/components/Toast/index.tsx
+++ b/extension/src/components/Toast/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Slide, ToastContainer } from 'react-toastify'
+
+import classes from './Toast.module.css'
+
+const ZodiacToastContainer: React.FC = () => {
+  return (
+    <ToastContainer
+      theme="dark"
+      transition={Slide}
+      bodyClassName={classes.toastBody}
+      progressClassName={classes.toastProgress}
+      toastClassName={classes.toast}
+    />
+  )
+}
+
+export default ZodiacToastContainer

--- a/extension/src/networks.ts
+++ b/extension/src/networks.ts
@@ -1,4 +1,6 @@
 export const RPC = {
+  1: 'https://mainnet.infura.io/v3/b81b456501e34bed8a85a3c2ff8f4577',
+  4: 'https://rinkeby.infura.io/v3/b81b456501e34bed8a85a3c2ff8f4577',
   100: 'https://rpc.gnosischain.com/',
 }
 

--- a/extension/src/providers/WrappingProvider.ts
+++ b/extension/src/providers/WrappingProvider.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'events'
 
 import { Interface } from '@ethersproject/abi'
 import { JsonRpcSigner, Web3Provider } from '@ethersproject/providers'
+import { MetaTransaction } from 'react-multisend'
 
 import rolesAbi from '../abi/Roles.json'
 import { Eip1193Provider, TransactionData } from '../types'
@@ -9,14 +10,21 @@ import { Eip1193Provider, TransactionData } from '../types'
 const RolesInterface = new Interface(rolesAbi)
 
 export function wrapRequest(
-  request: TransactionData,
+  request: MetaTransaction | TransactionData,
   from: string,
   to: string,
   roleId: string
 ): TransactionData {
   const data = RolesInterface.encodeFunctionData(
     'execTransactionWithRole(address,uint256,bytes,uint8,uint16,bool)',
-    [request.to, request.value || 0, request.data, 0, roleId || 0, true]
+    [
+      request.to,
+      request.value || 0,
+      request.data,
+      ('operation' in request && request.operation) || 0,
+      roleId || 0,
+      true,
+    ]
   )
 
   return {

--- a/extension/src/providers/useWalletConnect.ts
+++ b/extension/src/providers/useWalletConnect.ts
@@ -32,17 +32,18 @@ class WalletConnectEip1193Provider extends EventEmitter {
 
   constructor(connectionId: string) {
     super()
-
     this.wcProvider = new WalletConnectEthereumProvider({
-      infuraId: 'b81b456501e34bed8a85a3c2ff8f4577',
       storageId: `walletconnect-${connectionId}`,
       rpc: RPC,
     })
 
     // @ts-expect-error signer is a private property, but we didn't find another way
-    this.wcProvider.signer.on('connect', (ev: Event) => {
-      console.log(`WalletConnect connected: ${connectionId}`, ev)
-      this.emit('connect', ev)
+    this.wcProvider.signer.on('connect', () => {
+      const { chainId } = this.wcProvider
+      // @ts-expect-error setHttpProvider is a private method, but we need to call it fix a bug in @walletconnect/ethereum-provider
+      this.wcProvider.http = this.wcProvider.setHttpProvider(chainId)
+      console.log(`WalletConnect connected: ${connectionId}`, chainId)
+      this.emit('connect', { chainId })
     })
 
     this.wcProvider.on('disconnect', (ev: Event) => {

--- a/extension/src/settings/Connection/useSafeModuleInfo.ts
+++ b/extension/src/settings/Connection/useSafeModuleInfo.ts
@@ -1,5 +1,6 @@
 import { Web3Provider } from '@ethersproject/providers'
-import Safe, { EthersAdapter } from '@gnosis.pm/safe-core-sdk'
+import Safe, { ContractManager } from '@gnosis.pm/safe-core-sdk'
+import EthersAdapter from '@gnosis.pm/safe-ethers-lib'
 import { ethers } from 'ethers'
 import { useEffect, useState } from 'react'
 

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -21,6 +21,13 @@ export interface JsonRpcRequest {
   params?: Array<any>
 }
 
+export interface JsonRpcError extends Error {
+  data: {
+    code: number
+    message?: string
+  }
+}
+
 export interface Eip1193Provider {
   request(request: JsonRpcRequest): Promise<unknown>
   on(event: string, listener: (...args: any[]) => void): void

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -938,7 +938,7 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
-"@ethersproject/solidity@5.7.0", "@ethersproject/solidity@^5.0.0":
+"@ethersproject/solidity@5.7.0", "@ethersproject/solidity@^5.0.0", "@ethersproject/solidity@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
   integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
@@ -1026,11 +1026,6 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@gnosis.pm/safe-core-sdk-types@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-types/-/safe-core-sdk-types-0.1.1.tgz#908c394cb4660493b4e9c8e01b5a7aa36efafd30"
-  integrity sha512-PghXGDaI5Foq37nZGmI90U2OKMeGtxh5KqkDqou9aFHwGVa/nf9HRQPxG9/XUzcyfe9OlKttDlJnR3XnC3dSDw==
-
 "@gnosis.pm/safe-core-sdk-types@^1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-types/-/safe-core-sdk-types-1.6.1.tgz#dcd0c19d61fb5266b6e40bac1cd91fde44eda1d7"
@@ -1051,24 +1046,26 @@
     semver "^7.3.7"
     web3-utils "^1.8.0"
 
-"@gnosis.pm/safe-core-sdk@^1.1.1":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk/-/safe-core-sdk-1.3.0.tgz#ba21c6163c6a06e3fc51f5c7dac650e46fe8a779"
-  integrity sha512-laKkyJUv0llPPG5ep2+18v/anIEGi+KjarNoeVAutYzIeAAkSvvVbY8qyfczh5bWQkqvQ3K1l/QLUJ8Kx4hm3g==
+"@gnosis.pm/safe-core-sdk@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk/-/safe-core-sdk-3.1.1.tgz#d609e51fce387b8f12148965a3a053bd50b05b3d"
+  integrity sha512-RhU7ENNHvqD8SDGwUDSp8PirNzR48N7IlfAmFWSdhVqpqnCUW2Pzaxcn+e/E+rLx3GhZRvM2T6Cl98+JjWQwog==
   dependencies:
-    "@gnosis.pm/safe-core-sdk-types" "^0.1.1"
-    "@gnosis.pm/safe-deployments" "^1.7.0"
-    ethereumjs-util "^7.1.3"
-    semver "^7.3.5"
+    "@ethersproject/solidity" "^5.7.0"
+    "@gnosis.pm/safe-core-sdk-types" "^1.6.1"
+    "@gnosis.pm/safe-deployments" "1.16.0"
+    ethereumjs-util "^7.1.5"
+    semver "^7.3.7"
+    web3-utils "^1.8.0"
 
-"@gnosis.pm/safe-deployments@1.16.0", "@gnosis.pm/safe-deployments@^1.7.0":
+"@gnosis.pm/safe-deployments@1.16.0":
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.16.0.tgz#78b1fb400934ff117f7d9c8e66398503bd772eeb"
   integrity sha512-5Wakso6SiulstuZfz3gH6yME8Q50BT5dVxIfgWz4vzOmyyqmAVstMd0VIwyw6IDee0gU4mHKZjhD3UXPKEvRCw==
   dependencies:
     semver "^7.3.7"
 
-"@gnosis.pm/safe-ethers-lib@^1.1.0":
+"@gnosis.pm/safe-ethers-lib@^1.6.0":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-ethers-lib/-/safe-ethers-lib-1.6.1.tgz#2fe88464faa348d4dbe58e93199c419976a5da88"
   integrity sha512-rUv2Dwi3whTmcgx6EejI5llMDnxhwyTX/8j01K6fWBfOAFaUV78gbtPcwmdr1WCVVcXSdKszyarus5fyZTKNfA==
@@ -1077,7 +1074,7 @@
     "@gnosis.pm/safe-core-sdk-utils" "^1.4.1"
     ethers "^5.7.1"
 
-"@gnosis.pm/safe-service-client@^1.0.1":
+"@gnosis.pm/safe-service-client@^1.3.0":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-service-client/-/safe-service-client-1.3.1.tgz#e16e7855258cae6bf1ef6d3f6838b1f48ce5f509"
   integrity sha512-Gy2RjF0tvQs23nFlPQGpuFam2W3x1BxyHDd+RnYcNn9NUsoVmPjeGc85okpxWjpU6tl85ccovWl5fZrflIH1Vw==
@@ -1834,7 +1831,7 @@
   resolved "https://registry.yarnpkg.com/@walletconnect/environment/-/environment-1.0.0.tgz#c4545869fa9c389ec88c364e1a5f8178e8ab5034"
   integrity sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ==
 
-"@walletconnect/ethereum-provider@^1.6.6":
+"@walletconnect/ethereum-provider@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-1.8.0.tgz#ed1dbf9cecc3b818758a060d2f9017c50bde1d32"
   integrity sha512-Nq9m+oo5P0F+njsROHw9KMWdoc/8iGHYzQdkjJN/1C7DtsqFRg5k5a3hd9rzCLpbPsOC1q8Z5lRs6JQgDvPm6Q==
@@ -3829,7 +3826,7 @@ ethereum-cryptography@^0.1.3:
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
 
-ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.3:
+ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.5:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz#9ecf04861e4fbbeed7465ece5f23317ad1129181"
   integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==
@@ -6785,7 +6782,7 @@ secp256k1@4.0.3, secp256k1@^4.0.1:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7:
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==

--- a/landing-page/public/manifest.json
+++ b/landing-page/public/manifest.json
@@ -6,7 +6,7 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
+    }
   ],
   "start_url": ".",
   "display": "standalone",


### PR DESCRIPTION
This PR fixes a critical error when submitting multiple transactions. It used the wrong multi-send contract address and the wrong operation type (`call` instead of `delegatecall`).

While at it, I also made sure that errors on submit are shown to the user in a toast.

I also added a button to copy the batch transaction data to the clipboard, which might be useful for debugging purposes or when needing to use the transaction data in some way other than directly submitting it via WalletConnect. 

