### PR TITLE
Fix styles overwritten by react-scripts

### DIFF
--- a/landing-page/src/App.css
+++ b/landing-page/src/App.css
@@ -1,6 +1,6 @@
 .container {
   padding: 3%;
-  font-size: calc(24px + (24 - 16) * (100vw - 400px) / (800-400));
+  font-size: clamp(1.333rem, 1vw + 0.75rem, 3.333rem);
 }
 
 .main {
@@ -8,7 +8,7 @@
   display: grid;
   grid-template-columns: minmax(300px, 1fr) minmax(500px, 1.6fr);
   gap: 0;
-  max-width: 1500px;
+  max-width: 2500px;
   margin: 0 auto;
 }
 
@@ -20,7 +20,7 @@ h1 {
 }
 
 .descriptionContainer {
-  padding: 15% 0 0 15%;
+  padding: 25% 0 0 15%;
 }
 
 .description {
@@ -69,7 +69,7 @@ li::marker {
 }
 
 .demo {
-  padding: 3em 1em;
+  padding: 9% 5% 0;
 }
 
 .videoContainer {
@@ -77,7 +77,7 @@ li::marker {
 }
 
 video {
-  transform: rotateY(315deg);
+  transform: rotateY(330deg);
   width: 100%;
   box-shadow: 7px 14px 34px rgba(98, 89, 58, 0.5);
 }


### PR DESCRIPTION
For an unknown reason, `react-scripts` was calculating/overwriting a `font-size` rule in the css. I changed the rule to use less parentheses math, and this fixes the issue.

I also adjusted some of the layout styles