### PR TITLE
adjust error decoding to fix MetaMask dry run

### DIFF
--- a/extension/src/settings/Connection/useSafeModuleInfo.ts
+++ b/extension/src/settings/Connection/useSafeModuleInfo.ts
@@ -1,5 +1,5 @@
 import { Web3Provider } from '@ethersproject/providers'
-import Safe, { ContractManager } from '@gnosis.pm/safe-core-sdk'
+import Safe from '@gnosis.pm/safe-core-sdk'
 import EthersAdapter from '@gnosis.pm/safe-ethers-lib'
 import { ethers } from 'ethers'
 import { useEffect, useState } from 'react'

--- a/extension/src/utils/decodeRolesError.ts
+++ b/extension/src/utils/decodeRolesError.ts
@@ -11,19 +11,21 @@ const KNOWN_ERRORS = Object.keys(rolesInterface.errors).concat(
 // where <HEX_CODE> is either an ASCII string or an error sighash.
 export default function decodeError(message: string) {
   const prefix = 'Reverted 0x'
-  if (message.startsWith(prefix)) {
-    const reason = message.substring(prefix.length - 2)
+  const revertData = message.startsWith(prefix)
+    ? message.substring(prefix.length - 2)
+    : message
 
+  if (revertData.startsWith('0x')) {
     const error =
       Object.keys(rolesInterface.errors).find(
-        (errSig) => rolesInterface.getSighash(errSig) === reason
+        (errSig) => rolesInterface.getSighash(errSig) === revertData
       ) ||
       Object.keys(permissionsInterface.errors).find(
-        (errSig) => permissionsInterface.getSighash(errSig) === reason
+        (errSig) => permissionsInterface.getSighash(errSig) === revertData
       )
     if (error) return error
 
-    return asciiDecode(reason.substring(2))
+    return asciiDecode(revertData.substring(2))
   }
 
   return message


### PR DESCRIPTION
The extension currently does not work when connecting with MetaMask. That is due to changes in the structure of the JavaScript error object that is thrown by MetaMask in case of reverts. 

This PR adjusts error decoding so we can again correctly detect the expected error in the dry run.