### PR TITLE
Top bar tweaks

### DIFF
--- a/extension/src/browser/index.module.css
+++ b/extension/src/browser/index.module.css
@@ -27,6 +27,7 @@
   background-color: rgba(217, 212, 173, 0.1);
   min-width: 300px;
   position: relative;
+  flex: 1;
 }
 
 .urlInput .input {

--- a/extension/src/browser/index.tsx
+++ b/extension/src/browser/index.tsx
@@ -1,13 +1,10 @@
 import React, { useEffect, useState } from 'react'
 
-import { AppPicker, BlockLink, Box } from '../components'
-import { AddressStack } from '../components'
+import { AppPicker, Box } from '../components'
 import ConnectionBubble from '../components/ConnectionBubble'
 import Layout from '../components/Layout'
 import { pushLocation, useLocation } from '../location'
 import { ProvideTenderly } from '../providers'
-import { useSettingsHash } from '../routing'
-import { useConnection } from '../settings'
 
 import Drawer from './Drawer'
 import BrowserFrame from './Frame'

--- a/extension/src/browser/index.tsx
+++ b/extension/src/browser/index.tsx
@@ -42,6 +42,7 @@ const Browser: React.FC = () => {
         <ProvideProvider simulate>
           <Layout
             navBox={<UrlInput onSubmit={setInitialLocation} />}
+            navFullWidth
             headerRight={
               <BlockLink href={settingsHash}>
                 <AddressStack

--- a/extension/src/browser/index.tsx
+++ b/extension/src/browser/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 
 import { AppPicker, BlockLink, Box } from '../components'
 import { AddressStack } from '../components'
+import ConnectionBubble from '../components/ConnectionBubble'
 import Layout from '../components/Layout'
 import { pushLocation, useLocation } from '../location'
 import { ProvideTenderly } from '../providers'
@@ -33,8 +34,6 @@ const Browser: React.FC = () => {
   // When the user browses in the iframe the location will update constantly.
   // This must not trigger an update of the iframe's src prop, though, since that would rerender the iframe.
   const [initialLocation, setInitialLocation] = useState(location)
-  const { connection } = useConnection()
-  const settingsHash = useSettingsHash(connection.id)
 
   return (
     <ProvideTenderly>
@@ -43,16 +42,7 @@ const Browser: React.FC = () => {
           <Layout
             navBox={<UrlInput onSubmit={setInitialLocation} />}
             navFullWidth
-            headerRight={
-              <BlockLink href={settingsHash}>
-                <AddressStack
-                  interactive
-                  pilotAddress={connection.pilotAddress}
-                  moduleAddress={connection.moduleAddress}
-                  avatarAddress={connection.avatarAddress}
-                />
-              </BlockLink>
-            }
+            headerRight={<ConnectionBubble />}
           >
             <Box className={classNames.frame} double p={2}>
               {initialLocation ? (

--- a/extension/src/components/Address/index.tsx
+++ b/extension/src/components/Address/index.tsx
@@ -5,6 +5,7 @@ import React, { useMemo } from 'react'
 import { RiExternalLinkLine, RiFileCopyLine } from 'react-icons/ri'
 
 import { useConnection } from '../../settings'
+import Blockie from '../Blockie'
 import Box from '../Box'
 import IconButton from '../IconButton'
 
@@ -48,18 +49,13 @@ const Address: React.FC<Props> = ({
   } = useConnection()
   const explorerUrl = chainId && EXPLORER_URLS[chainId]
 
-  const blockie = useMemo(() => address && makeBlockie(address), [address])
   const displayAddress = shortenAddress(address)
 
   return (
-    <Box roundedRight className={cn(className, classes.container)}>
+    <Box rounded className={cn(className, classes.container)}>
       <div className={classes.address}>{displayAddress}</div>
       <Box rounded>
-        {address && (
-          <div className={classes.blockies}>
-            <img src={blockie} alt={address} />
-          </div>
-        )}
+        {address && <Blockie address={address} className={classes.blockies} />}
       </Box>
       {copyToClipboard && (
         <IconButton

--- a/extension/src/components/Address/style.module.css
+++ b/extension/src/components/Address/style.module.css
@@ -9,12 +9,6 @@
 }
 
 .blockies {
-  overflow: hidden;
-  border-radius: 50%;
-  height: 20px;
-  width: 20px;
-}
-.blockies img {
   height: 20px;
   width: 20px;
 }

--- a/extension/src/components/AddressStack/index.tsx
+++ b/extension/src/components/AddressStack/index.tsx
@@ -30,7 +30,7 @@ const AddressStack: React.FC<Props> = ({
       className={cn(classes.addressStack, interactive && classes.interactive)}
     >
       <Box
-        roundedRight
+        rounded
         double
         p={2}
         className={cn([classes.address, addressBoxClass])}

--- a/extension/src/components/AddressStack/index.tsx
+++ b/extension/src/components/AddressStack/index.tsx
@@ -10,8 +10,8 @@ interface Props {
   avatarAddress: string
   moduleAddress: string
   pilotAddress: string
-  interactive?: boolean
   helperClass?: string
+  staticLabels?: boolean
   addressBoxClass?: string
 }
 
@@ -19,15 +19,17 @@ const AddressStack: React.FC<Props> = ({
   avatarAddress,
   moduleAddress,
   pilotAddress,
-  interactive,
   helperClass,
+  staticLabels = false,
   addressBoxClass,
 }) => {
   const redundant = avatarAddress === moduleAddress
 
   return (
     <div
-      className={cn(classes.addressStack, interactive && classes.interactive)}
+      className={cn(classes.addressStack, {
+        [classes.staticLabels]: staticLabels,
+      })}
     >
       <Box
         rounded

--- a/extension/src/components/AddressStack/style.module.css
+++ b/extension/src/components/AddressStack/style.module.css
@@ -16,10 +16,10 @@
 .addressStack {
   display: flex;
 }
-.addressStack.interactive:hover .address,
-.addressStack.interactive:hover .address:before {
+/* .addressStack:hover .address,
+.addressStack:hover .address:before {
   border-color: rgba(217, 212, 173, 0.5);
-}
+} */
 .address:first-child > div {
   padding-left: var(--spacing-3);
 }
@@ -39,5 +39,9 @@
   left: 8px;
 }
 .addressStack.interactive:hover .helper {
+  opacity: 1;
+}
+
+.staticLabels .helper {
   opacity: 1;
 }

--- a/extension/src/components/AddressStack/style.module.css
+++ b/extension/src/components/AddressStack/style.module.css
@@ -21,7 +21,7 @@
   border-color: rgba(217, 212, 173, 0.5);
 }
 .address:first-child > div {
-  padding-left: var(--spacing-2);
+  padding-left: var(--spacing-3);
 }
 
 .helper {

--- a/extension/src/components/Blockie/index.tsx
+++ b/extension/src/components/Blockie/index.tsx
@@ -1,0 +1,21 @@
+import classNames from 'classnames'
+import makeBlockie from 'ethereum-blockies-base64'
+import React, { useMemo } from 'react'
+
+import classes from './style.module.css'
+
+interface Props {
+  address: string
+  className?: string
+}
+
+const Blockie: React.FC<Props> = ({ address, className }) => {
+  const blockie = useMemo(() => address && makeBlockie(address), [address])
+  return (
+    <div className={classNames(classes.container, className)}>
+      <img src={blockie} alt={address} />
+    </div>
+  )
+}
+
+export default Blockie

--- a/extension/src/components/Blockie/style.module.css
+++ b/extension/src/components/Blockie/style.module.css
@@ -1,0 +1,9 @@
+.container {
+  overflow: hidden;
+  border-radius: 50%;
+}
+
+.container img {
+  display: block;
+  height: 100%;
+}

--- a/extension/src/components/ConnectionBubble/index.tsx
+++ b/extension/src/components/ConnectionBubble/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+import { useSettingsHash } from '../../routing'
+import { useConnection } from '../../settings'
+import BlockLink from '../BlockLink'
+import Blockie from '../Blockie'
+import Box from '../Box'
+import Flex from '../Flex'
+
+import classes from './style.module.css'
+
+const ConnectionBubble: React.FC = () => {
+  const { connection } = useConnection()
+  const settingsHash = useSettingsHash(connection.id)
+  return (
+    <BlockLink href={settingsHash}>
+      <Box double bg rounded className={classes.container}>
+        <Flex justifyContent="space-between" alignItems="center" gap={3}>
+          <div className={classes.blockieStack}>
+            <Box rounded className={classes.blockieBox}>
+              <Blockie
+                address={connection.pilotAddress}
+                className={classes.blockie}
+              />
+            </Box>
+            <Box rounded className={classes.blockieBox}>
+              <Blockie
+                address={connection.moduleAddress}
+                className={classes.blockie}
+              />
+            </Box>
+            <Box rounded className={classes.blockieBox}>
+              <Blockie
+                address={connection.avatarAddress}
+                className={classes.blockie}
+              />
+            </Box>
+          </div>
+          {connection.label}
+        </Flex>
+      </Box>
+    </BlockLink>
+  )
+}
+
+export default ConnectionBubble

--- a/extension/src/components/ConnectionBubble/index.tsx
+++ b/extension/src/components/ConnectionBubble/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { useSettingsHash } from '../../routing'
 import { useConnection } from '../../settings'
+import AddressStack from '../AddressStack'
 import BlockLink from '../BlockLink'
 import Blockie from '../Blockie'
 import Box from '../Box'
@@ -38,6 +39,16 @@ const ConnectionBubble: React.FC = () => {
           </div>
           <p className={classes.label}>{connection.label}</p>
         </Flex>
+        <div className={classes.infoContainer}>
+          <Box bg rounded p={3} className={classes.info}>
+            <AddressStack
+              staticLabels
+              pilotAddress={connection.pilotAddress}
+              moduleAddress={connection.moduleAddress}
+              avatarAddress={connection.avatarAddress}
+            />
+          </Box>
+        </div>
       </Box>
     </BlockLink>
   )

--- a/extension/src/components/ConnectionBubble/index.tsx
+++ b/extension/src/components/ConnectionBubble/index.tsx
@@ -36,7 +36,7 @@ const ConnectionBubble: React.FC = () => {
               />
             </Box>
           </div>
-          {connection.label}
+          <p className={classes.label}>{connection.label}</p>
         </Flex>
       </Box>
     </BlockLink>

--- a/extension/src/components/ConnectionBubble/style.module.css
+++ b/extension/src/components/ConnectionBubble/style.module.css
@@ -1,0 +1,27 @@
+.container {
+  padding-right: var(--spacing-4);
+}
+
+.container:hover {
+  border-color: rgba(217, 212, 173, 0.8);
+}
+
+.blockieBox {
+  margin-left: -1em;
+  background: #292116;
+}
+
+.blockie {
+  height: 100%;
+}
+
+.blockieBox:first-child {
+  margin-left: 0;
+}
+
+.blockieStack {
+  display: flex;
+  height: 42px;
+  box-sizing: border-box;
+  padding: 4px;
+}

--- a/extension/src/components/ConnectionBubble/style.module.css
+++ b/extension/src/components/ConnectionBubble/style.module.css
@@ -33,3 +33,26 @@
   white-space: nowrap;
   overflow: hidden;
 }
+
+.infoContainer {
+  opacity: 0;
+  position: absolute;
+  z-index: 100;
+  bottom: -112px;
+  right: -5px;
+  padding-top: 30px;
+  transition: all 0.2s;
+  pointer-events: none;
+}
+
+.container:hover .infoContainer {
+  pointer-events: all;
+  opacity: 1;
+}
+
+.info {
+  background-color: rgb(35 34 25 / 64%);
+  border-color: rgba(217, 212, 173, 0.8);
+  padding-top: 35px;
+  border-radius: 33px;
+}

--- a/extension/src/components/ConnectionBubble/style.module.css
+++ b/extension/src/components/ConnectionBubble/style.module.css
@@ -25,3 +25,11 @@
   box-sizing: border-box;
   padding: 4px;
 }
+
+.label {
+  max-width: 380px;
+  margin: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/extension/src/components/Drawer/style.module.css
+++ b/extension/src/components/Drawer/style.module.css
@@ -35,7 +35,7 @@
 
 .toggleContainer {
   position: absolute;
-  top: -2%;
+  top: -12px;
   left: -3%;
 }
 

--- a/extension/src/components/Flex/index.tsx
+++ b/extension/src/components/Flex/index.tsx
@@ -5,7 +5,13 @@ import classes from './style.module.css'
 
 interface Props {
   direction?: 'row' | 'column'
-  justifyContent?: 'space-around' | 'space-between' | 'center' | 'end' | 'start'
+  justifyContent?:
+    | 'space-around'
+    | 'space-between'
+    | 'center'
+    | 'end'
+    | 'start'
+    | 'right'
   alignItems?: 'normal' | 'stretch' | 'center' | 'end' | 'start'
   gap: 0 | 1 | 2 | 3 | 4
   className?: string

--- a/extension/src/components/Layout/Layout.module.css
+++ b/extension/src/components/Layout/Layout.module.css
@@ -27,3 +27,11 @@ button.appName {
   border-width: 1px;
   background-color: rgba(217, 212, 173, 0.1);
 }
+
+.fullWidthNavContainer {
+  flex: 1;
+}
+
+.fullWidthNav {
+  width: 100%;
+}

--- a/extension/src/components/Layout/index.tsx
+++ b/extension/src/components/Layout/index.tsx
@@ -25,7 +25,7 @@ const Layout: React.FC<Props> = ({
   return (
     <div className={classes.page}>
       <div className={classes.topBar}>
-        <Flex gap={4} justifyContent="space-between" alignItems="center">
+        <Flex gap={4} justifyContent="space-between" alignItems="stretch">
           <Box
             className={classNames({
               [classes.fullWidthNavContainer]: navFullWidth,

--- a/extension/src/components/Layout/index.tsx
+++ b/extension/src/components/Layout/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React from 'react'
 
 import { usePushSettingsRoute } from '../../routing'
@@ -11,16 +12,29 @@ interface Props {
   children: React.ReactNode
   headerRight: React.ReactNode
   navBox: React.ReactNode
+  navFullWidth?: boolean
 }
 
-const Layout: React.FC<Props> = ({ children, headerRight, navBox }) => {
+const Layout: React.FC<Props> = ({
+  children,
+  headerRight,
+  navBox,
+  navFullWidth = false,
+}) => {
   const pushSettingsRoute = usePushSettingsRoute()
   return (
     <div className={classes.page}>
       <div className={classes.topBar}>
-        <Flex gap={3} justifyContent="space-between" alignItems="center">
-          <Box>
-            <Flex gap={1}>
+        <Flex gap={4} justifyContent="space-between" alignItems="center">
+          <Box
+            className={classNames({
+              [classes.fullWidthNavContainer]: navFullWidth,
+            })}
+          >
+            <Flex
+              gap={1}
+              className={classNames({ [classes.fullWidthNav]: navFullWidth })}
+            >
               <Button
                 className={classes.appName}
                 onClick={() => pushSettingsRoute('')}

--- a/extension/src/settings/Connection/Select.tsx
+++ b/extension/src/settings/Connection/Select.tsx
@@ -60,7 +60,7 @@ const ConnectionItem: React.FC<{
             justifyContent="space-between"
             alignItems="center"
           >
-            <Flex direction="row" gap={2}>
+            <Flex direction="row" gap={2} className={classes.labelContainer}>
               <h3>{connection.label}</h3>
 
               <div className={classes.status}>

--- a/extension/src/settings/Connection/style.module.css
+++ b/extension/src/settings/Connection/style.module.css
@@ -17,15 +17,24 @@ h2 {
   font-size: 1.5em;
   margin: 0em 0em 0.5em 0em;
 }
-h3 {
+.labelContainer {
+  overflow: hidden;
+}
+
+.labelContainer h3 {
   font-size: 1.4em;
   margin-bottom: 0;
   line-height: 1.2;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 .connectionItem {
   position: relative;
 }
 .connectionButton {
+  overflow: hidden;
   width: 100%;
   height: 8em;
   padding: calc(var(--spacing-3) - 1px);

--- a/extension/src/settings/index.tsx
+++ b/extension/src/settings/index.tsx
@@ -57,7 +57,7 @@ const Settings: React.FC<Props> = ({
   return connections.some((c) => c.id === editConnectionId) ? (
     <Layout
       navBox={
-        <Flex gap={1}>
+        <Flex gap={1} className={classes.navStack}>
           <Box p={2} className={classes.navLabel}>
             Settings
           </Box>
@@ -67,7 +67,7 @@ const Settings: React.FC<Props> = ({
         </Flex>
       }
       headerRight={
-        <Flex gap={3}>
+        <Flex gap={3} justifyContent="right">
           <Button
             className={classes.headerButton}
             disabled={!canLaunch}

--- a/extension/src/settings/style.module.css
+++ b/extension/src/settings/style.module.css
@@ -11,6 +11,17 @@
   line-height: 1.7;
   padding-left: 24px;
   padding-right: 24px;
+  margin: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.navLabel:last-child {
+  text-overflow: ellipsis;
+}
+
+.navStack {
+  overflow: hidden;
 }
 
 button.headerButton {


### PR DESCRIPTION
I made the address bar use all the available space in the top bar, and now the connection label shows instead of the address stack (which now will show on hover). Connection label has a limited width, so super long labels will get truncated with `...`

![Screen Shot 2022-11-09 at 12 53 21 PM](https://user-images.githubusercontent.com/6718506/200904293-18fc0203-2edf-49bb-ae30-e8c2d7b9333d.png)
![Screen Shot 2022-11-09 at 12 53 27 PM](https://user-images.githubusercontent.com/6718506/200904300-8106c759-dffc-445d-ac46-3cee13ce4752.png)
