### PR TITLE
Edit Page UX

### DIFF
--- a/extension/src/components/Field/index.tsx
+++ b/extension/src/components/Field/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { ReactNode } from 'react'
 
 import Box from '../Box'
@@ -8,8 +9,9 @@ const Field: React.FC<{
   label?: string
   labelFor?: string
   children: ReactNode
-}> = ({ label, labelFor, children }) => (
-  <Box double bg p={3}>
+  disabled?: boolean
+}> = ({ label, labelFor, children, disabled = false }) => (
+  <Box double bg p={3} className={classNames({ [classes.disabled]: disabled })}>
     {label ? (
       <label htmlFor={labelFor}>
         <div className={classes.fieldLabel}>{label}</div>

--- a/extension/src/components/Field/style.module.css
+++ b/extension/src/components/Field/style.module.css
@@ -1,3 +1,8 @@
 .fieldLabel {
   margin-bottom: 0.3em;
 }
+
+.disabled {
+  opacity: 0.8;
+  pointer-events: none;
+}

--- a/extension/src/components/Select/ModSelect.tsx
+++ b/extension/src/components/Select/ModSelect.tsx
@@ -12,15 +12,18 @@ interface LabelProps {
   label: string
 }
 
-const ModuleOptionLabel: React.FC<LabelProps> = ({ value, label }) => {
+// react-select can't infer the type of Option here, so it expects unknown,
+// hence the weird typing method below
+const ModuleOptionLabel = (data: unknown) => {
+  const props = data as LabelProps
   return (
     <div className={classes.modOption}>
       <Box rounded>
-        <Blockie address={value} className={classes.modBlockie} />
+        <Blockie address={props.value} className={classes.modBlockie} />
       </Box>
       <div className={classes.modLabel}>
-        <p className={classes.type}>{label}</p>
-        <p className={classes.address}>{value}</p>
+        <p className={classes.type}>{props.label}</p>
+        <p className={classes.address}>{props.value}</p>
       </div>
     </div>
   )

--- a/extension/src/components/Select/ModSelect.tsx
+++ b/extension/src/components/Select/ModSelect.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Props } from 'react-select'
+
+import { Select } from '..'
+import Blockie from '../Blockie'
+import Box from '../Box'
+
+import classes from './style.module.css'
+
+interface LabelProps {
+  value: string
+  label: string
+}
+
+const ModuleOptionLabel: React.FC<LabelProps> = ({ value, label }) => {
+  return (
+    <div className={classes.modOption}>
+      <Box rounded>
+        <Blockie address={value} className={classes.modBlockie} />
+      </Box>
+      <div className={classes.modLabel}>
+        <p className={classes.type}>{label}</p>
+        <p className={classes.address}>{value}</p>
+      </div>
+    </div>
+  )
+}
+
+const ModSelect: React.FC<Props> = (props) => {
+  return (
+    <Select
+      {...props}
+      formatOptionLabel={ModuleOptionLabel}
+      noOptionsMessage={() => 'No modules are enabled on this Safe'}
+    />
+  )
+}
+
+export default ModSelect

--- a/extension/src/components/Select/index.tsx
+++ b/extension/src/components/Select/index.tsx
@@ -42,7 +42,12 @@ const customStyles = {
     ...provided,
     zIndex: 10,
     borderRadius: 0,
-    background: 'rgb(29 27 14 / 70%)',
+    background: 'rgb(0 0 0 / 95%)',
+    marginTop: 0,
+  }),
+  menuList: (provided: React.CSSProperties) => ({
+    ...provided,
+    padding: 0,
   }),
   singleValue: (provided: React.CSSProperties) => ({
     ...provided,

--- a/extension/src/components/Select/index.tsx
+++ b/extension/src/components/Select/index.tsx
@@ -27,20 +27,22 @@ const customStyles = {
   }),
   option: (provided: React.CSSProperties, state: any) => ({
     ...provided,
-    background: state.isSelected ? 'rgba(217, 212, 173, 0.5)' : 'none',
+    background: state.isSelected
+      ? 'rgba(217, 212, 173, 0.2)'
+      : 'rgba(217, 212, 173, 0.2)',
     color: 'white',
     fontFamily: "'Roboto Mono', monospace",
     fontSize: '14px',
     cursor: 'pointer',
     '&:hover': {
-      background: 'rgba(217, 212, 173, 0.2)',
+      background: 'rgba(217, 212, 173, 0.1)',
     },
   }),
   menu: (provided: React.CSSProperties) => ({
     ...provided,
     zIndex: 10,
     borderRadius: 0,
-    background: 'black',
+    background: 'rgb(29 27 14 / 70%)',
   }),
   singleValue: (provided: React.CSSProperties) => ({
     ...provided,

--- a/extension/src/components/Select/style.module.css
+++ b/extension/src/components/Select/style.module.css
@@ -1,7 +1,7 @@
 .modOption {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   padding: 12px 0;
 }
 

--- a/extension/src/components/Select/style.module.css
+++ b/extension/src/components/Select/style.module.css
@@ -1,0 +1,30 @@
+.modOption {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+}
+
+.modOption .modBlockie {
+  width: 40px;
+  height: 40px;
+}
+
+.modLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.modLabel .type {
+  font-family: 'Spectra';
+  font-size: 1rem;
+  padding-left: 4px;
+}
+
+.modLabel .address {
+  padding: 4px 8px;
+  background: #3e3d2ad1;
+  border-radius: 4px;
+  border: 1px solid rgba(217, 212, 173, 0.3);
+}

--- a/extension/src/components/Tag/style.module.css
+++ b/extension/src/components/Tag/style.module.css
@@ -40,6 +40,6 @@
 }
 
 .body {
-  padding: 0 var(--spacing-2) 0 var(--spacing-1);
+  padding: 0 var(--spacing-2);
   font-size: 12px;
 }

--- a/extension/src/settings/Connection/ConnectButton/index.tsx
+++ b/extension/src/settings/Connection/ConnectButton/index.tsx
@@ -66,14 +66,16 @@ const ConnectButton: React.FC<{ id: string }> = ({ id }) => {
   // good to go
   if (connected) {
     return (
-      <div className={classes.connectedAccount}>
-        <div className={classes.walletLogo}>
-          {connection.providerType === ProviderType.WalletConnect
-            ? walletConnectLogo
-            : metamaskLogo}
-        </div>
-        <div className={classes.connectedAddress}>
-          {connection.pilotAddress}
+      <div className={classes.connectedContainer}>
+        <div className={classes.connectedAccount}>
+          <div className={classes.walletLogo}>
+            {connection.providerType === ProviderType.WalletConnect
+              ? walletConnectLogo
+              : metamaskLogo}
+          </div>
+          <div className={classes.connectedAddress}>
+            {connection.pilotAddress}
+          </div>
         </div>
         <Button onClick={disconnect} className={classes.disconnectButton}>
           Disconnect
@@ -94,8 +96,8 @@ const ConnectButton: React.FC<{ id: string }> = ({ id }) => {
     return (
       <div
         className={classNames(
-          classes.connectedAccount,
-          classes.connectedAddress
+          classes.connectedContainer,
+          classes.connectionWarning
         )}
       >
         <Tag head={<RiAlertLine />} color="warning">
@@ -140,8 +142,8 @@ const ConnectButton: React.FC<{ id: string }> = ({ id }) => {
     !metamask.accounts.includes(connection.pilotAddress)
   ) {
     return (
-      <div className={classes.connectedAccount}>
-        <div className={classes.connectedAddress}>
+      <div className={classes.connectedContainer}>
+        <div className={classes.connectionWarning}>
           <Tag head={<RiAlertLine />} color="warning">
             Switch wallet to account {shortenAddress(connection.pilotAddress)}
           </Tag>

--- a/extension/src/settings/Connection/ConnectButton/style.module.css
+++ b/extension/src/settings/Connection/ConnectButton/style.module.css
@@ -1,33 +1,37 @@
-.connectedAccount {
+.connectedContainer {
   position: relative;
   margin-top: 4px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px;
+  padding: 8px 10px;
   border: 1px solid rgba(217, 212, 173, 0.8);
+  box-sizing: border-box;
+  min-height: 66px;
+}
+
+.connectedAccount {
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .walletLogo {
   border: 1px solid rgba(0, 166, 56, 0.47);
-  height: 30px;
-  width: 30px;
+  height: 46px;
+  width: 46px;
   display: flex;
   justify-content: center;
   align-items: center;
   position: relative;
   border-radius: 50px;
-  margin-right: 8px;
 }
 
 .walletLogo:before {
   content: ' ';
   position: absolute;
   z-index: 1;
-  top: 3px;
-  left: 3px;
-  right: 3px;
-  bottom: 3px;
+  inset: 3px;
   border: 1px solid rgba(0, 166, 56, 0.47);
   border-radius: 50px;
   pointer-events: none;
@@ -38,6 +42,15 @@
 }
 
 .connectedAddress {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 14px;
+  padding: 4px 8px;
+  background: #3e3d2ad1;
+  border-radius: 4px;
+  border: 1px solid rgba(217, 212, 173, 0.3);
+}
+
+.connectionWarning {
   font-family: 'Roboto Mono', monospace;
   font-size: 14px;
 }

--- a/extension/src/settings/Connection/Edit.tsx
+++ b/extension/src/settings/Connection/Edit.tsx
@@ -91,7 +91,10 @@ const EditConnection: React.FC<Props> = ({ id }) => {
               }}
             />
           </Field>
-          <Field label="Zodiac Modifier or Module address">
+          <Field
+            label="Zodiac Modifier or Module address"
+            disabled={modules.length === 0}
+          >
             <ModSelect
               options={modules.map((mod) => ({
                 value: mod.moduleAddress,

--- a/extension/src/settings/Connection/Edit.tsx
+++ b/extension/src/settings/Connection/Edit.tsx
@@ -2,6 +2,8 @@ import { KnownContracts } from '@gnosis.pm/zodiac'
 import React from 'react'
 
 import { Box, Field, Flex, Select } from '../../components'
+import Blockie from '../../components/Blockie'
+import ModSelect from '../../components/Select/ModSelect'
 import { useConnection, useConnections } from '../connectionHooks'
 import useConnectionDryRun from '../useConnectionDryRun'
 
@@ -90,10 +92,10 @@ const EditConnection: React.FC<Props> = ({ id }) => {
             />
           </Field>
           <Field label="Zodiac Modifier or Module address">
-            <Select
+            <ModSelect
               options={modules.map((mod) => ({
                 value: mod.moduleAddress,
-                label: `${mod.moduleAddress} (${MODULE_NAMES[mod.type]})`,
+                label: MODULE_NAMES[mod.type],
               }))}
               onChange={(selected) => {
                 const mod = modules.find(
@@ -110,15 +112,12 @@ const EditConnection: React.FC<Props> = ({ id }) => {
                 selectedModule
                   ? {
                       value: selectedModule.moduleAddress,
-                      label: `${selectedModule.moduleAddress} (${
-                        MODULE_NAMES[selectedModule.type]
-                      })`,
+                      label: MODULE_NAMES[selectedModule.type],
                     }
                   : ''
               }
               isDisabled={loading || !isValidSafe}
               placeholder={loading || !isValidSafe ? '' : 'Select a module'}
-              noOptionsMessage={() => 'No modules are enabled on this Safe'}
             />
           </Field>
           {selectedModule?.type === KnownContracts.ROLES && (

--- a/extension/src/settings/Connection/Edit.tsx
+++ b/extension/src/settings/Connection/Edit.tsx
@@ -1,7 +1,8 @@
 import { KnownContracts } from '@gnosis.pm/zodiac'
 import React from 'react'
+import { RiAlertLine } from 'react-icons/ri'
 
-import { Box, Field, Flex, Select } from '../../components'
+import { Box, Button, Field, Flex, IconButton, Select } from '../../components'
 import Blockie from '../../components/Blockie'
 import ModSelect from '../../components/Select/ModSelect'
 import { useConnection, useConnections } from '../connectionHooks'
@@ -53,15 +54,17 @@ const EditConnection: React.FC<Props> = ({ id }) => {
   return (
     <Flex direction="column" gap={3}>
       <Flex direction="column" gap={2}>
-        {error && (
-          <>
-            <div>There seems to be a problem with this connection:</div>
-            <Box p={3} className={classes.error}>
-              {error}
-            </Box>
-          </>
-        )}
         <Flex direction="column" gap={3} className={classes.form}>
+          {error && (
+            <Box double p={3}>
+              <div className={classes.errorInfo}>
+                <p>There seems to be a problem with this connection:</p>
+                <Box p={3} className={classes.error}>
+                  {error}
+                </Box>
+              </div>
+            </Box>
+          )}
           <Field label="Connection name">
             <input
               type="text"
@@ -77,19 +80,51 @@ const EditConnection: React.FC<Props> = ({ id }) => {
           <Field label="Pilot Account" labelFor="">
             <ConnectButton id={id} />
           </Field>
-          <Field label="Impersonated Safe">
-            <input
-              type="text"
-              value={avatarAddress}
-              onChange={(ev) => {
-                const avatarAddress = ev.target.value.replace(/^[a-z]{3}:/g, '')
-                updateConnection({
-                  avatarAddress,
-                  moduleAddress: '',
-                  moduleType: undefined,
-                })
-              }}
-            />
+          <Field label="Impersonated Safe" labelFor="">
+            {connection.avatarAddress.length > 0 ? (
+              <div className={classes.avatarContainer}>
+                <div className={classes.avatar}>
+                  <Box rounded>
+                    <Blockie
+                      address={connection.avatarAddress}
+                      className={classes.avatarBlockie}
+                    />
+                  </Box>
+                  <div className={classes.avatarAddress}>
+                    {connection.avatarAddress}
+                  </div>
+                </div>
+                <Button
+                  className={classes.removeButton}
+                  onClick={() => {
+                    updateConnection({
+                      avatarAddress: '',
+                      moduleAddress: '',
+                      moduleType: undefined,
+                    })
+                  }}
+                >
+                  Remove
+                </Button>
+              </div>
+            ) : (
+              <input
+                type="text"
+                value={avatarAddress}
+                placeholder="Paste in Safe address"
+                onChange={(ev) => {
+                  const avatarAddress = ev.target.value.replace(
+                    /^[a-z]{3}:/g,
+                    ''
+                  )
+                  updateConnection({
+                    avatarAddress,
+                    moduleAddress: '',
+                    moduleType: undefined,
+                  })
+                }}
+              />
+            )}
           </Field>
           <Field
             label="Zodiac Modifier or Module address"

--- a/extension/src/settings/Connection/style.module.css
+++ b/extension/src/settings/Connection/style.module.css
@@ -8,11 +8,6 @@
   width: 28px;
 }
 
-.error {
-  color: crimson;
-  font-family: 'Roboto Mono', monospace;
-  font-size: 14px;
-}
 h2 {
   font-size: 1.5em;
   margin: 0em 0em 0.5em 0em;
@@ -56,4 +51,57 @@ button.connectionEdit {
 .connectionButton:hover .addressBox,
 .connectionButton:hover .addressBox:before {
   border-color: rgba(217, 212, 173, 0.5);
+}
+
+.avatarContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border: 1px solid rgba(217, 212, 173, 0.8);
+}
+
+.avatar {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.avatarAddress {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 14px;
+  background: #3e3d2ad1;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid rgba(217, 212, 173, 0.3);
+}
+
+.avatarBlockie {
+  width: 40px;
+  height: 40px;
+}
+
+button.removeButton {
+  background: none;
+  width: fit-content;
+  padding: 4px 8px;
+  font-size: 14px;
+}
+
+.errorIcon {
+  color: crimson;
+  font-size: 1.7em;
+}
+
+.errorInfo {
+  flex-grow: 1;
+}
+
+.error {
+  margin-top: 12px;
+  color: crimson;
+  background: #f4433640;
+  border: none;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 14px;
 }

--- a/extension/src/settings/Connection/useZodiacModules.ts
+++ b/extension/src/settings/Connection/useZodiacModules.ts
@@ -92,7 +92,7 @@ async function fetchModules(
           type = match[0]
         }
       }
-      console.log(type)
+
       if (!type || !SUPPORTED_MODULES.includes(type)) {
         return undefined
       }

--- a/extension/src/settings/Connection/useZodiacModules.ts
+++ b/extension/src/settings/Connection/useZodiacModules.ts
@@ -92,7 +92,7 @@ async function fetchModules(
           type = match[0]
         }
       }
-
+      console.log(type)
       if (!type || !SUPPORTED_MODULES.includes(type)) {
         return undefined
       }

--- a/extension/src/settings/index.tsx
+++ b/extension/src/settings/index.tsx
@@ -90,11 +90,11 @@ const Settings: React.FC<Props> = ({
       }
     >
       <Box p={2} className={classes.body}>
-        <Box p={3} className={classes.edit}>
+        <div className={classes.edit}>
           <Flex direction="column" gap={3}>
             <EditConnection id={editConnectionId} />
           </Flex>
-        </Box>
+        </div>
       </Box>
     </Layout>
   ) : (

--- a/extension/src/settings/style.module.css
+++ b/extension/src/settings/style.module.css
@@ -48,7 +48,7 @@ button.removeButton:hover {
 }
 
 .edit {
-  margin: 0 auto;
+  margin: 30px auto;
   max-width: 700px;
 }
 


### PR DESCRIPTION
Adjusting the UX on the edit page to be a little more user friendly
- added blockies to safe and mod selection
- made the 'Impersonated Safe' look a little more stout when connected, and made removing it a button instead of deleting from a text input
- adjusted the Connect Button to more closely match the new components below it
- error style reads a bit better


![Screen Shot 2022-11-16 at 4 56 01 PM](https://user-images.githubusercontent.com/6718506/202303191-2a2aace0-7d48-4df8-8e54-c903a3feb732.png)
