### PR TITLE
Direct connect UX improvements 

### DIFF
--- a/extension/src/components/Select/index.tsx
+++ b/extension/src/components/Select/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import Select, { Props } from 'react-select'
 
-const customStyles = {
+export const selectStyles = {
   control: (provided: React.CSSProperties, state: any) => ({
     ...provided,
     fontFamily: "'Roboto Mono', monospace",
@@ -21,6 +21,7 @@ const customStyles = {
   }),
   input: (provided: React.CSSProperties) => ({
     ...provided,
+    color: 'white',
     margin: 0,
     paddingBottom: 0,
     paddingTop: 0,
@@ -56,7 +57,7 @@ const customStyles = {
 }
 
 const StyledSelect: React.FC<Props> = (props) => {
-  return <Select {...props} styles={customStyles as any} />
+  return <Select {...props} styles={selectStyles as any} />
 }
 
 export default StyledSelect

--- a/extension/src/providers/safe.ts
+++ b/extension/src/providers/safe.ts
@@ -152,7 +152,6 @@ export const useSafeDelegates = (safeAddress: string) => {
 
   useEffect(() => {
     if (!connected || !chainId || !checksumSafeAddress) return
-
     const txServiceUrl = TX_SERVICE_URL[chainId as ChainId]
     if (!txServiceUrl) {
       throw new Error(`service not available for chain #${chainId}`)

--- a/extension/src/settings/Connection/AvatarInput/index.tsx
+++ b/extension/src/settings/Connection/AvatarInput/index.tsx
@@ -1,5 +1,6 @@
 import { getAddress } from 'ethers/lib/utils'
 import React, { useEffect, useState } from 'react'
+import { components, InputProps } from 'react-select'
 import CreatableSelect from 'react-select/creatable'
 
 import { Box, Button } from '../../../components'
@@ -58,7 +59,26 @@ const AvatarInput: React.FC<Props> = ({
   }, [value])
 
   const checksumAvatarAddress = validateAddress(pendingValue)
-  console.log('pending', pendingValue, checksumAvatarAddress)
+
+  const Input = (props: InputProps<Option>) => {
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const sanitized = e.target.value.trim().replace(/^[a-z]{3}:/g, '')
+      setPendingValue(sanitized)
+      if (validateAddress(sanitized)) {
+        onChange(sanitized.toLowerCase())
+      }
+    }
+    console.log(props)
+
+    return (
+      <components.Input
+        {...props}
+        onChange={handleInputChange}
+        value={checksumAvatarAddress ? '' : pendingValue}
+      />
+    )
+  }
+
   return (
     <>
       {availableSafes.length > 0 || checksumAvatarAddress ? (
@@ -87,17 +107,10 @@ const AvatarInput: React.FC<Props> = ({
               onChange('')
             }
           }}
-          isValidNewOption={(value) => {
-            console.log('initial value', value)
-            if (value) {
-              const sanitized = value.trim().replace(/^[a-z]{3}:/g, '')
-              if (validateAddress(sanitized)) {
-                console.log('valiudd')
-                onChange(sanitized.toLowerCase())
-              }
-            }
+          isValidNewOption={() => {
             return false
           }}
+          components={{ Input }}
         />
       ) : (
         <input

--- a/extension/src/settings/Connection/AvatarInput/index.tsx
+++ b/extension/src/settings/Connection/AvatarInput/index.tsx
@@ -1,57 +1,135 @@
+import { getAddress } from 'ethers/lib/utils'
 import React, { useEffect, useState } from 'react'
+import CreatableSelect from 'react-select/creatable'
 
 import { Box, Button } from '../../../components'
 import Blockie from '../../../components/Blockie'
+import { selectStyles } from '../../../components/Select'
 import { validateAddress } from '../../../utils'
+import { Option } from '../ModSelect'
 
 import classes from './style.module.css'
 
 interface Props {
   value: string
+  availableSafes?: string[]
   onChange(value: string): void
 }
 
-const AvatarInput: React.FC<Props> = ({ value, onChange }) => {
+const createSelectStyles = {
+  ...selectStyles,
+  dropdownIndicator: (provided: React.CSSProperties, state: any) => {
+    if (state.options.length === 0) {
+      return {
+        ...provided,
+        display: 'none',
+      }
+    }
+    return {
+      ...provided,
+    }
+  },
+  indicatorSeparator: (provided: React.CSSProperties, state: any) => {
+    if (state.options.length === 0) {
+      return {
+        ...provided,
+        display: 'none',
+      }
+    }
+    return {
+      ...provided,
+    }
+  },
+  indicatorContainer: (provided: React.CSSProperties) => ({
+    ...provided,
+    color: 'white',
+  }),
+}
+
+const AvatarInput: React.FC<Props> = ({
+  value,
+  onChange,
+  availableSafes = [],
+}) => {
   const [pendingValue, setPendingValue] = useState(value)
+
   useEffect(() => {
     setPendingValue(value)
   }, [value])
 
   const checksumAvatarAddress = validateAddress(pendingValue)
+  console.log('pending', pendingValue, checksumAvatarAddress)
+  return (
+    <>
+      {availableSafes.length > 0 || checksumAvatarAddress ? (
+        <CreatableSelect
+          isClearable
+          formatOptionLabel={SafeOptionLabel}
+          placeholder="Paste in Safe address or select from owned Safes"
+          styles={createSelectStyles as any}
+          value={
+            checksumAvatarAddress && {
+              value: checksumAvatarAddress,
+              label: checksumAvatarAddress,
+            }
+          }
+          options={availableSafes.map((address) => {
+            return { value: address, label: address }
+          })}
+          onChange={(opt) => {
+            const option = opt as Option
+            if (option) {
+              const sanitized = option.value.trim().replace(/^[a-z]{3}:/g, '')
+              if (validateAddress(sanitized)) {
+                onChange(sanitized.toLowerCase())
+              }
+            } else {
+              onChange('')
+            }
+          }}
+          isValidNewOption={(value) => {
+            console.log('initial value', value)
+            if (value) {
+              const sanitized = value.trim().replace(/^[a-z]{3}:/g, '')
+              if (validateAddress(sanitized)) {
+                console.log('valiudd')
+                onChange(sanitized.toLowerCase())
+              }
+            }
+            return false
+          }}
+        />
+      ) : (
+        <input
+          type="text"
+          value={pendingValue}
+          placeholder="Paste in Safe address"
+          onChange={(ev) => {
+            const sanitized = ev.target.value.trim().replace(/^[a-z]{3}:/g, '')
+            setPendingValue(sanitized)
+            if (validateAddress(sanitized)) {
+              onChange(sanitized.toLowerCase())
+            }
+          }}
+        />
+      )}
+    </>
+  )
+}
 
-  return checksumAvatarAddress ? (
-    <div className={classes.avatarContainer}>
-      <div className={classes.avatar}>
-        <Box rounded>
-          <Blockie
-            address={checksumAvatarAddress}
-            className={classes.avatarBlockie}
-          />
-        </Box>
-        <code className={classes.avatarAddress}>{checksumAvatarAddress}</code>
+const SafeOptionLabel: React.FC<unknown> = (opt) => {
+  const option = opt as Option
+
+  const checksumAddress = getAddress(option.value)
+  return (
+    <div className={classes.safeOption}>
+      <Box rounded>
+        <Blockie address={option.value} className={classes.safeBlockie} />
+      </Box>
+      <div className={classes.safeLabel}>
+        <code className={classes.address}>{checksumAddress}</code>
       </div>
-      <Button
-        className={classes.removeButton}
-        onClick={() => {
-          onChange('')
-        }}
-      >
-        Remove
-      </Button>
     </div>
-  ) : (
-    <input
-      type="text"
-      value={pendingValue}
-      placeholder="Paste in Safe address"
-      onChange={(ev) => {
-        const sanitized = ev.target.value.trim().replace(/^[a-z]{3}:/g, '')
-        setPendingValue(sanitized)
-        if (validateAddress(sanitized)) {
-          onChange(sanitized.toLowerCase())
-        }
-      }}
-    />
   )
 }
 

--- a/extension/src/settings/Connection/AvatarInput/style.module.css
+++ b/extension/src/settings/Connection/AvatarInput/style.module.css
@@ -27,3 +27,31 @@ button.removeButton {
   padding: 4px 8px;
   font-size: 14px;
 }
+
+.safeOption {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 0;
+}
+
+.safeOption .safeBlockie {
+  width: 40px;
+  height: 40px;
+}
+
+.safeLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.safeLabel .type {
+  font-family: 'Spectra';
+  font-size: 1rem;
+  padding-left: 4px;
+}
+
+.safeLabel .address {
+  font-size: 14px;
+}

--- a/extension/src/settings/Connection/Edit.tsx
+++ b/extension/src/settings/Connection/Edit.tsx
@@ -8,7 +8,7 @@ import useConnectionDryRun from '../useConnectionDryRun'
 
 import AvatarInput from './AvatarInput'
 import ConnectButton from './ConnectButton'
-import ModSelect, { NO_MODULE_OPTION } from './ModSelect'
+import ModSelect, { NO_MODULE_OPTION, Option } from './ModSelect'
 import classes from './style.module.css'
 import {
   MODULE_NAMES,
@@ -97,8 +97,9 @@ const EditConnection: React.FC<Props> = ({ id }) => {
           <Field label="Pilot Account" labelFor="">
             <ConnectButton id={id} />
           </Field>
-          <Field label="Impersonated Safe" labelFor="">
+          <Field label="Piloted Safe" labelFor="">
             <AvatarInput
+              availableSafes={safes}
               value={avatarAddress}
               onChange={(address) =>
                 updateConnection({
@@ -120,9 +121,7 @@ const EditConnection: React.FC<Props> = ({ id }) => {
               ]}
               onChange={(selected) => {
                 const mod = modules.find(
-                  (mod) =>
-                    mod.moduleAddress ===
-                    (selected as { value: string; label: string }).value
+                  (mod) => mod.moduleAddress === (selected as Option).value
                 )
                 updateConnection({
                   moduleAddress: mod?.moduleAddress,

--- a/extension/src/settings/Connection/ModSelect/index.tsx
+++ b/extension/src/settings/Connection/ModSelect/index.tsx
@@ -9,7 +9,7 @@ import Box from '../../../components/Box'
 import classes from './style.module.css'
 
 export const NO_MODULE_OPTION = { value: '', label: '' }
-interface Option {
+export interface Option {
   value: string
   label: string
 }
@@ -36,8 +36,10 @@ const NoModuleOptionLabel = () => {
   return (
     <div className={classes.modOption}>
       <div className={classes.modLabel}>
-        <p className={classes.type}>&lt;No mod&gt;</p>
-        <code className={classes.address}>Direct execution</code>
+        <p className={classes.type}>Direct execution</p>
+        <code className={classes.address}>
+          Transactions submitted directly to the Safe
+        </code>
       </div>
     </div>
   )


### PR DESCRIPTION
This adds an input / drop down element that allows users to paste in addresses or choose from safes they are owners of. If the wallet is not an owner of any safe, a standard input is used.

![Screen Shot 2022-12-05 at 8 43 01 PM](https://user-images.githubusercontent.com/6718506/205788009-721ce1f1-567c-477e-8d4b-7ce854c69a77.png)
![Screen Shot 2022-12-05 at 8 43 10 PM](https://user-images.githubusercontent.com/6718506/205788016-b7dc89c7-4e9d-4ca8-8644-0447f27ea6cf.png)
![Screen Shot 2022-12-05 at 8 43 40 PM](https://user-images.githubusercontent.com/6718506/205788021-a69894d9-5356-4585-b1a1-b603e4a8804f.png)
