### PR TITLE
fix tenderly simulation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ TODO: The following is still true, but we should adjust the implementation now t
 ### Submitting transactions
 
 A batch of recorded transaction can finally be submitted as a multi-send transaction.
-Zodiac Pilot can be configured to submit transactions directly to the Safe if the Pilot account is an owner of delegate, or to route the transaction through Zodiac mods.
+Zodiac Pilot can be configured to submit transactions directly to the Safe if the Pilot account is an owner or delegate, or to route the transaction through Zodiac mods.
 This is implemented in [WrappingProvider](src/providers/WrappingProvider.ts).
 It currently supports the [Roles](https://github.com/gnosis/zodiac-modifier-roles) and [Delay](https://github.com/gnosis/zodiac-modifier-delay) mods.
 

--- a/extension/src/providers/ProvideTenderly.tsx
+++ b/extension/src/providers/ProvideTenderly.tsx
@@ -239,7 +239,7 @@ export class TenderlyProvider extends EventEmitter {
     const json = await res.json()
     return {
       ...json.fork_transaction,
-      dashboardLink: `https://dashboard.tenderly.co/gnosisguild/zodiac-pilot/fork/${this.forkId}/simulation/${transactionId}`,
+      dashboardLink: `https://dashboard.tenderly.co/public/gnosisguild/zodiac-pilot/fork-simulation/${transactionId}`,
     }
   }
 }


### PR DESCRIPTION
The previous links only worked for authenticated members of our Tenderly org 🙈 