### PR TITLE
fix: check if tx is eligible for translation

### DIFF
--- a/extension/src/transactionTranslations/index.ts
+++ b/extension/src/transactionTranslations/index.ts
@@ -9,11 +9,7 @@ export const findApplicableTranslation = (
   transaction: MetaTransaction
 ): TransactionTranslation | undefined => {
   for (const translation of translations) {
-    try {
-      if (translation.translate(transaction)) return translation
-    } catch (e) {
-      continue
-    }
+    if (translation.translate(transaction)) return translation
   }
   return undefined
 }

--- a/extension/src/transactionTranslations/index.ts
+++ b/extension/src/transactionTranslations/index.ts
@@ -9,7 +9,11 @@ export const findApplicableTranslation = (
   transaction: MetaTransaction
 ): TransactionTranslation | undefined => {
   for (const translation of translations) {
-    if (translation.translate(transaction)) return translation
+    try {
+      if (translation.translate(transaction)) return translation
+    } catch (e) {
+      continue
+    }
   }
   return undefined
 }

--- a/extension/src/transactionTranslations/uniswapMulticall.ts
+++ b/extension/src/transactionTranslations/uniswapMulticall.ts
@@ -16,7 +16,7 @@ export default {
 
   translate: (transaction) => {
     if (!transaction.data) {
-      throw Error("Invalid translation: transaction doesn't have data")
+      return undefined
     }
 
     let functionCalls: string[] = []
@@ -34,7 +34,7 @@ export default {
     }
 
     if (functionCalls.length === 0) {
-      throw Error("Invalid translation: couldn't decode function data")
+      return undefined
     }
 
     return functionCalls.map((data) => ({ ...transaction, data }))

--- a/extension/src/transactionTranslations/uniswapMulticall.ts
+++ b/extension/src/transactionTranslations/uniswapMulticall.ts
@@ -15,7 +15,9 @@ export default {
   recommendedFor: [KnownContracts.ROLES],
 
   translate: (transaction) => {
-    if (!transaction.data) return [transaction]
+    if (!transaction.data) {
+      throw Error("Invalid translation: transaction doesn't have data")
+    }
 
     let functionCalls: string[] = []
     for (const fragment of uniswapMulticallInterface.fragments) {
@@ -31,10 +33,10 @@ export default {
       }
     }
 
-    if (functionCalls.length > 0) {
-      return functionCalls.map((data) => ({ ...transaction, data }))
+    if (functionCalls.length === 0) {
+      throw Error("Invalid translation: couldn't decode function data")
     }
 
-    return [transaction]
+    return functionCalls.map((data) => ({ ...transaction, data }))
   },
 } satisfies TransactionTranslation


### PR DESCRIPTION
The function used to check if a transaction was eligible for a translation (`findApplicableTranslation`) was broken.

A change is required in the translations. The `translate` function a `TransactionTranslation` should throw an error if a transaction cannot be translated.