### PR TITLE
Account switching

### DIFF
--- a/extension/src/bridge/host.ts
+++ b/extension/src/bridge/host.ts
@@ -1,4 +1,4 @@
-import { Eip1193Provider } from '../types'
+import { Connection, Eip1193Provider } from '../types'
 
 interface Request {
   method: string
@@ -7,14 +7,31 @@ interface Request {
 
 export default class BridgeHost {
   private provider: Eip1193Provider
+  private connection: Connection
   private source: WindowProxy | undefined
 
-  constructor(provider: Eip1193Provider) {
+  constructor(provider: Eip1193Provider, connection: Connection) {
     this.provider = provider
+    this.connection = connection
   }
 
   setProvider(provider: Eip1193Provider) {
     this.provider = provider
+  }
+
+  setConnection(connection: Connection) {
+    if (connection?.avatarAddress !== this.connection?.avatarAddress) {
+      this.source?.postMessage(
+        {
+          zodiacPilotBridgeConnectionChange: true,
+          account: connection.avatarAddress,
+          chainId: connection.chainId,
+        },
+        '*'
+      )
+    }
+
+    this.connection = connection
   }
 
   initBridge(event: MessageEvent<any>) {
@@ -54,7 +71,6 @@ export default class BridgeHost {
   handleMessage(ev: MessageEvent<any>) {
     const {
       zodiacPilotBridgeInit,
-
       zodiacPilotBridgeRequest,
       messageId,
       request,

--- a/extension/src/bridge/host.ts
+++ b/extension/src/bridge/host.ts
@@ -20,15 +20,12 @@ export default class BridgeHost {
   }
 
   setConnection(connection: Connection) {
-    if (connection?.avatarAddress !== this.connection?.avatarAddress) {
-      this.source?.postMessage(
-        {
-          zodiacPilotBridgeConnectionChange: true,
-          account: connection.avatarAddress,
-          chainId: connection.chainId,
-        },
-        '*'
-      )
+    if (connection.avatarAddress !== this.connection.avatarAddress) {
+      this.emitBridgeEvent('accountsChanged', [[connection.avatarAddress]])
+    }
+
+    if (connection.chainId !== this.connection.chainId) {
+      this.emitBridgeEvent('chainChanged', [connection.chainId])
     }
 
     this.connection = connection
@@ -43,6 +40,19 @@ export default class BridgeHost {
       throw new Error('Expected message to originate from window')
     }
     this.source = event.source
+  }
+
+  private emitBridgeEvent(event: string, args: any[]) {
+    if (!this.source) throw new Error('source must be set')
+
+    this.source.postMessage(
+      {
+        zodiacPilotBridgeEvent: true,
+        event,
+        args,
+      },
+      '*'
+    )
   }
 
   private async handleRequest(request: Request, messageId: number) {

--- a/extension/src/bridge/iframe.ts
+++ b/extension/src/bridge/iframe.ts
@@ -35,16 +35,15 @@ export default class BridgeIframe extends EventEmitter {
       })
     })
 
-    const handleAccountChange = (ev: MessageEvent) => {
-      const { zodiacPilotBridgeConnectionChange, account, chainId } = ev.data
-      if (!zodiacPilotBridgeConnectionChange) {
+    const handleBridgeEvent = (ev: MessageEvent) => {
+      const { zodiacPilotBridgeEvent, event, args } = ev.data
+      if (!zodiacPilotBridgeEvent) {
         return
       }
-      this.emit('accountsChanged', [account])
-      this.emit('chainChanged', chainId.toString(16))
+      this.emit(event, ...args)
     }
 
-    window.addEventListener('message', handleAccountChange)
+    window.addEventListener('message', handleBridgeEvent)
   }
 
   request(request: JsonRpcRequest): Promise<any> {

--- a/extension/src/bridge/iframe.ts
+++ b/extension/src/bridge/iframe.ts
@@ -34,6 +34,17 @@ export default class BridgeIframe extends EventEmitter {
         chainId,
       })
     })
+
+    const handleAccountChange = (ev: MessageEvent) => {
+      const { zodiacPilotBridgeConnectionChange, account, chainId } = ev.data
+      if (!zodiacPilotBridgeConnectionChange) {
+        return
+      }
+      this.emit('accountsChanged', [account])
+      this.emit('chainChanged', chainId.toString(16))
+    }
+
+    window.addEventListener('message', handleAccountChange)
   }
 
   request(request: JsonRpcRequest): Promise<any> {

--- a/extension/src/browser/Frame.tsx
+++ b/extension/src/browser/Frame.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 
 import BridgeHost from '../bridge/host'
+import { useConnection } from '../settings'
 
 import { useProvider } from './ProvideProvider'
 
@@ -10,15 +11,17 @@ type Props = {
 
 const BrowserFrame: React.FC<Props> = ({ src }) => {
   const provider = useProvider()
+  const { connection } = useConnection()
   const bridgeHostRef = useRef<BridgeHost | null>(null)
 
   useEffect(() => {
     if (!provider) return
 
     if (!bridgeHostRef.current) {
-      bridgeHostRef.current = new BridgeHost(provider)
+      bridgeHostRef.current = new BridgeHost(provider, connection)
     } else {
       bridgeHostRef.current.setProvider(provider)
+      bridgeHostRef.current.setConnection(connection)
     }
 
     const handle = (ev: MessageEvent<any>) => {
@@ -29,7 +32,7 @@ const BrowserFrame: React.FC<Props> = ({ src }) => {
     return () => {
       window.removeEventListener('message', handle)
     }
-  }, [provider])
+  }, [provider, connection])
 
   return (
     <iframe

--- a/extension/src/providers/ForkProvider.ts
+++ b/extension/src/providers/ForkProvider.ts
@@ -37,6 +37,12 @@ class ForkProvider extends EventEmitter {
     const { method, params = [] } = request
 
     switch (method) {
+      case 'eth_chainId': {
+        const result = await this.provider.request(request)
+        // WalletConnect seems to return a number even though it must be a string value
+        return typeof result === 'number' ? `0x${result.toString(16)}` : result
+      }
+
       case 'eth_requestAccounts': {
         return [this.avatarAddress]
       }


### PR DESCRIPTION
With the new connections design inside a drawer the user would intuitively expect that "account switching" behaves like it does in other dapps.

This change will emit 2 events each time a new connection/provider is used:
- accountsChanged
- chainChanged

This should follow the EIP-1193 specification.

https://www.loom.com/share/3ff7b7af12c24cccbe25a56b79c45a40