### PR TITLE
Connections drawer tweaks

### DIFF
--- a/extension/src/browser/ConnectionsDrawer/Edit/index.tsx
+++ b/extension/src/browser/ConnectionsDrawer/Edit/index.tsx
@@ -102,17 +102,22 @@ const EditConnection: React.FC<Props> = ({ connectionId, onLaunched }) => {
     pilotIsOwner || pilotIsDelegate ? NO_MODULE_OPTION : ''
 
   return (
-    <Flex direction="column" gap={4}>
+    <Flex direction="column" gap={4} className={classes.editContainer}>
       <Flex gap={2} direction="column">
         <Flex gap={1} justifyContent="space-between" alignItems="baseline">
           <Flex gap={1} direction="column" alignItems="baseline">
             <h2>{connection.label}</h2>
-            <a className={classes.subtitle} href={connectionsHash}>
+            <a className={classes.backLink} href={connectionsHash}>
               &#8592; All Connections
             </a>
           </Flex>
-          <Flex gap={1} alignItems="center">
-            <Button onClick={handleLaunchConnection}>Launch</Button>
+          <Flex gap={4} alignItems="center">
+            <Button
+              className={classes.launchButton}
+              onClick={handleLaunchConnection}
+            >
+              Launch
+            </Button>
             <IconButton
               onClick={handleRemoveConnection}
               danger

--- a/extension/src/browser/ConnectionsDrawer/Edit/style.module.css
+++ b/extension/src/browser/ConnectionsDrawer/Edit/style.module.css
@@ -1,3 +1,6 @@
+.editContainer {
+  position: relative;
+}
 h2 {
   font-size: 1.5em;
   margin: 0em;
@@ -10,11 +13,16 @@ hr {
   margin: 0.5em 0 0 0;
 }
 
+.launchButton {
+  width: auto;
+  padding: 4px 24px;
+}
+
 button.removeButton {
   height: auto;
   width: auto;
   aspect-ratio: 1/1;
-  padding: 8px;
+  padding: 4px;
   border: 3px double crimson;
 }
 
@@ -22,8 +30,12 @@ button.removeButton:hover {
   background-color: rgba(220, 20, 60, 0.2);
 }
 
-.subtitle {
+.backLink {
+  position: absolute;
+  top: -30px;
+  left: 0;
   font-size: 0.8em;
+  text-decoration: none;
 }
 
 .form {

--- a/extension/src/browser/ConnectionsDrawer/List/index.tsx
+++ b/extension/src/browser/ConnectionsDrawer/List/index.tsx
@@ -44,89 +44,83 @@ const ConnectionItem: React.FC<ConnectionItemProps> = ({
   const handleModify = () => onModify(connection.id)
 
   return (
-    <Box className={classes.connectionItemContainer}>
-      <Flex direction="column" gap={4}>
-        <Flex
-          direction="row"
-          gap={2}
-          justifyContent="space-between"
-          className={classes.labelContainer}
-        >
-          <Flex direction="row" alignItems="center" gap={3}>
-            <Box className={classes.connectionIcon}>
-              {connected && (
-                <ConnectedIcon
-                  role="status"
-                  size={24}
-                  color="green"
-                  title="Pilot wallet is connected"
-                />
-              )}
-              {!connected && !connect && (
-                <DisconnectedIcon
-                  role="status"
-                  size={24}
-                  color="crimson"
-                  title="Pilot wallet is not connected"
-                />
-              )}
-              {!connected && connect && (
-                <ConnectedIcon
-                  role="status"
-                  size={24}
-                  color="orange"
-                  title="Pilot wallet is connected to a different chain"
-                />
-              )}
-            </Box>
-            <h2>{connection.label}</h2>
-          </Flex>
-          <Flex gap={3}>
-            <BoxButton
-              onClick={handleLaunch}
-              className={classes.connectionButton}
-            >
-              Connect
-            </BoxButton>
-            <BoxButton
-              onClick={handleModify}
-              className={classes.connectionButton}
-            >
-              Modify
-            </BoxButton>
-          </Flex>
-        </Flex>
-        <Flex
-          direction="row"
-          gap={5}
-          alignItems="baseline"
-          className={classes.infoContainer}
-        >
-          <ConnectionStack
-            connection={connection}
-            addressBoxClass={classes.addressBox}
-            className={classes.connectionStack}
-          />
+    <div className={classes.connection}>
+      <BoxButton
+        className={classes.connectionItemContainer}
+        onClick={handleLaunch}
+      >
+        <Flex direction="column" gap={4}>
           <Flex
-            direction="column"
-            alignItems="start"
+            direction="row"
             gap={2}
-            className={classes.info}
+            justifyContent="space-between"
+            className={classes.labelContainer}
           >
-            <div className={classes.infoDatum}>
-              {connection.lastUsed ? (
-                <Moment unix fromNow>
-                  {connection.lastUsed}
-                </Moment>
-              ) : (
-                <>N/A</>
-              )}
-            </div>
-            <div className={classes.infoLabel}>Last Used</div>
+            <Flex direction="row" alignItems="center" gap={3}>
+              <Box className={classes.connectionIcon}>
+                {connected && (
+                  <ConnectedIcon
+                    role="status"
+                    size={24}
+                    color="green"
+                    title="Pilot wallet is connected"
+                  />
+                )}
+                {!connected && !connect && (
+                  <DisconnectedIcon
+                    role="status"
+                    size={24}
+                    color="crimson"
+                    title="Pilot wallet is not connected"
+                  />
+                )}
+                {!connected && connect && (
+                  <ConnectedIcon
+                    role="status"
+                    size={24}
+                    color="orange"
+                    title="Pilot wallet is connected to a different chain"
+                  />
+                )}
+              </Box>
+              <h2>{connection.label}</h2>
+            </Flex>
+          </Flex>
+          <Flex
+            direction="row"
+            gap={4}
+            alignItems="baseline"
+            className={classes.infoContainer}
+          >
+            <ConnectionStack
+              connection={connection}
+              addressBoxClass={classes.addressBox}
+              className={classes.connectionStack}
+            />
+            <Flex
+              direction="column"
+              alignItems="start"
+              gap={2}
+              className={classes.info}
+            >
+              <div className={classes.infoDatum}>
+                {connection.lastUsed ? (
+                  <Moment unix fromNow>
+                    {connection.lastUsed}
+                  </Moment>
+                ) : (
+                  <>N/A</>
+                )}
+              </div>
+              <div className={classes.infoLabel}>Last Used</div>
+            </Flex>
           </Flex>
         </Flex>
-      </Flex>
-    </Box>
+      </BoxButton>
+      <BoxButton onClick={handleModify} className={classes.modifyButton}>
+        Modify
+      </BoxButton>
+    </div>
   )
 }
 

--- a/extension/src/browser/ConnectionsDrawer/List/style.module.css
+++ b/extension/src/browser/ConnectionsDrawer/List/style.module.css
@@ -27,12 +27,16 @@ button.removeButton:hover {
   padding: 4px 24px;
 }
 
+.connection {
+  position: relative;
+}
+
 .connectionItemContainer {
+  width: 100%;
   background-color: rgba(39, 38, 30, 0.7);
   border-color: rgba(255, 255, 255, 0.3);
   box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.1);
   padding: var(--spacing-4);
-
 }
 
 .connectionItemContainer:hover,
@@ -53,12 +57,15 @@ button.removeButton:hover {
   min-width: 505px;
 }
 
-.connectionButton {
+.modifyButton {
+  position: absolute;
+  top: var(--spacing-4);
+  right: var(--spacing-4);
   background: none;
   padding: var(--spacing-1) var(--spacing-3);
 }
 
-.connectionButton:before {
+.modifyButton:before {
   content: none;
 }
 

--- a/extension/src/browser/ConnectionsDrawer/index.tsx
+++ b/extension/src/browser/ConnectionsDrawer/index.tsx
@@ -22,8 +22,8 @@ const CloseDrawerButton: React.FC<CloseDrawerButtonProps> = ({ onClick }) => (
   <div className={classes.toggleContainer}>
     <IconButton onClick={onClick}>
       <div>
-        <Box rounded className={classes.toggleBackground}>
-          <Box rounded className={classes.toggle}>
+        <Box className={classes.toggleBackground}>
+          <Box className={classes.toggle}>
             <ConnectionsIcon width="auto" height="100%" />
           </Box>
         </Box>

--- a/extension/src/browser/ConnectionsDrawer/style.module.css
+++ b/extension/src/browser/ConnectionsDrawer/style.module.css
@@ -8,7 +8,7 @@
 
 .toggleContainer {
   position: absolute;
-  top: 38px;
+  top: 48px;
   left: 0;
   transform: translate(-50%);
   z-index: 9000;
@@ -31,7 +31,7 @@
 }
 
 .drawerContent {
-  padding: 40px 50px;
+  padding: 50px;
   overflow: auto;
   height: 100%;
   scrollbar-width: none;

--- a/extension/src/components/ConnectionBubble/index.tsx
+++ b/extension/src/components/ConnectionBubble/index.tsx
@@ -21,10 +21,10 @@ const ConnectionBubble: React.FC<ConnectionBubbleProps> = ({
   const { connection } = useConnection()
   const currentConnectionHash = useSettingsHash(connection.id)
   return (
-    <Box rounded>
-      <Flex gap={1}>
-        <BlockLink href={currentConnectionHash}>
-          <Box bg rounded className={classes.currentConnectionContainer}>
+    <BlockLink onClick={onConnectionsClick}>
+      <Box roundedLeft className={classes.connectionBubble}>
+        <Flex gap={1}>
+          <Box bg roundedLeft className={classes.currentConnectionContainer}>
             <Flex justifyContent="space-between" alignItems="center" gap={3}>
               <div className={classes.blockieStack}>
                 <Box rounded className={classes.blockieBox}>
@@ -50,20 +50,23 @@ const ConnectionBubble: React.FC<ConnectionBubbleProps> = ({
               </div>
               <p className={classes.label}>{connection.label}</p>
             </Flex>
-            <div className={classes.infoContainer}>
-              <Box bg rounded p={3} className={classes.info}>
-                <ConnectionStack connection={connection} />
-              </Box>
-            </div>
           </Box>
-        </BlockLink>
-        <BlockLink onClick={onConnectionsClick}>
-          <Box bg rounded className={classes.connectionsContainer}>
+          <Box bg className={classes.connectionsContainer}>
             <ConnectionsIcon height="100%" width="auto" />
           </Box>
-        </BlockLink>
-      </Flex>
-    </Box>
+        </Flex>
+        <div className={classes.infoContainer}>
+          <Box bg p={3} className={classes.info}>
+            <BlockLink href={currentConnectionHash}>
+              <ConnectionStack
+                connection={connection}
+                className={classes.stack}
+              />
+            </BlockLink>
+          </Box>
+        </div>
+      </Box>
+    </BlockLink>
   )
 }
 

--- a/extension/src/components/ConnectionBubble/index.tsx
+++ b/extension/src/components/ConnectionBubble/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useSettingsHash } from '../../routing'
+import { useConnectionsHash } from '../../routing'
 import { useConnection } from '../../settings'
 import BlockLink from '../BlockLink'
 import Blockie from '../Blockie'
@@ -19,7 +19,7 @@ const ConnectionBubble: React.FC<ConnectionBubbleProps> = ({
   onConnectionsClick,
 }) => {
   const { connection } = useConnection()
-  const currentConnectionHash = useSettingsHash(connection.id)
+  const currentConnectionHash = useConnectionsHash(connection.id)
   return (
     <BlockLink onClick={onConnectionsClick}>
       <Box roundedLeft className={classes.connectionBubble}>

--- a/extension/src/components/ConnectionBubble/style.module.css
+++ b/extension/src/components/ConnectionBubble/style.module.css
@@ -9,8 +9,9 @@
   height: 44px;
 }
 
-.currentConnectionContainer:hover,
-.connectionsContainer:hover {
+.connectionBubble:hover,
+.connectionBubble:hover .currentConnectionContainer,
+.connectionBubble:hover .connectionsContainer {
   border-color: rgba(217, 212, 173, 0.8);
 }
 
@@ -46,20 +47,23 @@
   opacity: 0;
   position: absolute;
   z-index: 100;
-  bottom: -130px;
-  right: -5px;
-  padding-top: 30px;
-  transition: all 0.2s;
+  bottom: -120px;
+  right: -1px;
+  padding-top: 20px;
   pointer-events: none;
-}
-
-.currentConnectionContainer:hover .infoContainer {
-  pointer-events: all;
-  opacity: 1;
+  transition: opacity 0.2s;
 }
 
 .info {
   background-color: rgb(35 34 25 / 64%);
+  backdrop-filter: blur(3px);
+  border-radius: 40px;
+}
+.connectionBubble:hover .infoContainer {
+  pointer-events: all;
+  opacity: 1;
+}
+
+.stack:hover * {
   border-color: rgba(217, 212, 173, 0.8);
-  border-radius: 33px;
 }

--- a/extension/src/routing.ts
+++ b/extension/src/routing.ts
@@ -27,9 +27,7 @@ export const useUrl = () => {
 
 export const useSettingsHash = (connectionId?: string) => {
   const url = useUrl()
-  const settingsPart = connectionId
-    ? `connections-${connectionId}`
-    : 'connections'
+  const settingsPart = connectionId ? `settings-${connectionId}` : 'settings'
   return '#' + encodeURIComponent(`${settingsPart};${url}`)
 }
 

--- a/extension/src/routing.ts
+++ b/extension/src/routing.ts
@@ -27,7 +27,9 @@ export const useUrl = () => {
 
 export const useSettingsHash = (connectionId?: string) => {
   const url = useUrl()
-  const settingsPart = connectionId ? `settings-${connectionId}` : 'settings'
+  const settingsPart = connectionId
+    ? `connections-${connectionId}`
+    : 'connections'
   return '#' + encodeURIComponent(`${settingsPart};${url}`)
 }
 


### PR DESCRIPTION
![Screen Shot 2023-01-30 at 2 55 16 PM](https://user-images.githubusercontent.com/6718506/215581656-127555b9-2a5f-4b70-a746-e8c6b428501b.png)

- all of the connection bubble is a single button / hover target
- clicking on the connection stack in the hover bubble takes u directly to the settings edit page


![Screen Shot 2023-01-30 at 3 35 04 PM](https://user-images.githubusercontent.com/6718506/215589159-8edae566-c0f0-47c5-83c2-04279505b1c1.png)
- brought back the connection item being a button (in an html semantic way, with no nested interactive elements)
- adjusted connection icon button to match square look of corner connection bubble

![Screen Shot 2023-01-30 at 3 35 08 PM](https://user-images.githubusercontent.com/6718506/215589168-67546498-789c-4341-b2b3-49ba47db831a.png)
- adjusted edit layout to move less when switching between the list and edit views
- adjusted button padding
