### PR TITLE
Fix wallet connection for Aura

### DIFF
--- a/extension/src/bridge/iframe.ts
+++ b/extension/src/bridge/iframe.ts
@@ -110,6 +110,8 @@ export default class BridgeIframe extends EventEmitter {
     return Promise.resolve()
   }
 
-  // Stakewise only supports MetaMask and Tally as injected providers, so we pretend to be MetaMask
-  isMetaMask = window.location.hostname === 'app.stakewise.io'
+  // Some apps don't support generic injected providers, so we pretend to be MetaMask
+  isMetaMask =
+    window.location.hostname === 'app.stakewise.io' ||
+    window.location.hostname === 'app.aura.finance'
 }


### PR DESCRIPTION
In a recent app update Aura seems to have removed the generic injected wallet connector in their rainbow kit config. This caused Pilot to not be detected by Aura anymore.

We work around this by impersonating MetaMask when injecting into Aura. 